### PR TITLE
Fix relative imports.

### DIFF
--- a/toytree/ete3mini.py
+++ b/toytree/ete3mini.py
@@ -17,7 +17,7 @@ import os
 
 #from six.moves import (cPickle, map, range, zip)
 from six.moves import (map, range, zip)
-from newick import read_newick, write_newick
+from .newick import read_newick, write_newick
 
 DEFAULT_EDGE_LENGTH = 1.
 DEFAULT_SUPPORT = 100.

--- a/toytree/tree.py
+++ b/toytree/tree.py
@@ -6,9 +6,8 @@ import toyplot
 import numpy as np
 import copy
 import re
-import ete3mini
-from decimal import Decimal
-#from toytree.ete3mini 
+from . import ete3mini
+from decimal import Decimal 
 
 # pylint: disable=W0212
 # pylint: disable=R0902


### PR DESCRIPTION
There are two relative imports breaking toytree in Python 3. This PR fixes those imports. 