### PR TITLE
bug fix! (and added vcv function)

### DIFF
--- a/toytree/PCM.py
+++ b/toytree/PCM.py
@@ -4,7 +4,7 @@
 PCM: phylogenetic comparative methods tools
 """
 
-# import numpy as np
+import numpy as np
 
 
 class PCM:
@@ -48,7 +48,7 @@ class PCM:
 
 
     def tree_to_VCV(self):
-        return VCV(self)
+        return VCV(self.tree)
 
 
 
@@ -56,7 +56,15 @@ def VCV(tree):
     """
     Return the variance co-variance metrix representing the tree topology.
     """
-    return 
+    vcv_ = np.zeros((tree.ntips,tree.ntips))
+    labs = tree.get_tip_labels()
+    for lab1 in range(tree.ntips):
+        for lab2 in range(tree.ntips):
+            mrca_idx = tree.get_mrca_idx_from_tip_labels([labs[lab1],labs[lab2]])
+            mrca_height = tree.treenode.search_nodes(idx=mrca_idx)[0].height
+            vcv_[lab1, lab2] = tree.treenode.height - mrca_height
+    return(vcv_)
+
 
 
 def PIC(tree, feature):

--- a/toytree/Toytree.py
+++ b/toytree/Toytree.py
@@ -531,10 +531,14 @@ class ToyTree(object):
         # make a copy
         nself = self.copy()
 
+        # make default ndict using idxs, regardless of whether values
+        ndict = nself.get_feature_dict("idx", None)
+
         # if numeric keys in values then use idx, else use names.
         if values:
             if isinstance(list(values.keys())[0], (int, float)):
-                ndict = nself.get_feature_dict("idx", None)
+                #ndict = nself.get_feature_dict("idx", None)
+                pass
             elif isinstance(list(values.keys())[0], (str, bytes)):
                 ndict = nself.get_feature_dict("name", None)
             else:


### PR DESCRIPTION
Was throwing an error when using tre.set_node_values("Ne", default=1e5, values=None), because making the node index was conditional on there being specific defined values.

VCV function also added to pcm -- only took a couple minutes to write it this quick way and so might not be super efficient... reckon that it could be sped up with a little more attention.