### PR TITLE
Improvements to bdtree

### DIFF
--- a/toytree/Randomtree.py
+++ b/toytree/Randomtree.py
@@ -257,7 +257,7 @@ class RandomTree(object):
             Random number generator seed.
 
         retain_extinct (bool):
-            Whether to retain internal nodes leading to extinct tips.
+            (Unimplemented) Whether to retain internal nodes leading to extinct tips.
 
         random_names (bool):
             Whether to randomize tip names or name them in order.
@@ -267,6 +267,9 @@ class RandomTree(object):
         """
         if stop not in ["taxa", "time"]:
             raise ToytreeError("stop must be either 'taxa' or 'time'")
+
+        taxa_stop = ntips
+        time_stop = time
 
         # set random seed
         if seed:
@@ -373,11 +376,6 @@ class RandomTree(object):
                     break
             else:
                 if t >= time_stop:
-                    break
-
-            # ntips stopping criterion.
-            else:
-                if len(tips) >= ntips:
                     break
 
         # report status

--- a/toytree/Randomtree.py
+++ b/toytree/Randomtree.py
@@ -224,7 +224,15 @@ class RandomTree(object):
 
 
     @staticmethod
-    def bdtree(ntips, b=1, d=0, maxtime=None, random_names=False, seed=None, verbose=False):
+    def bdtree(ntips=10,
+                time=4,
+                b=1,
+                d=0,
+                stop="taxa",
+                seed=None,
+                retain_extinct=False,
+                random_names=False,
+                verbose=False):
         """
         Generate a classic birth/death tree.
 
@@ -233,19 +241,26 @@ class RandomTree(object):
         ntips (int):
             Number of tips to generate for 'taxa' stopping criterion.
 
+        time (float):
+            Amount of time to simulate for 'time' stopping criterion.
+
         b (float):
             Birth rate per time unit
 
         d (float):
             Death rate per time unit (d=0 produces Yule trees)
 
-        maxtime (None or int):
-            if maxtime is int then stopping criterion is time and the ntips
-            argument is ignored. Simulations are conditional on tips existing
-            at maxtime, and will reset until a tree reaches maxtime.
+        stop (str):
+            Stopping critereon. Valid values are only 'taxa' or 'time'.
 
         seed (int):
             Random number generator seed.
+
+        retain_extinct (bool):
+            Whether to retain internal nodes leading to extinct tips.
+
+        random_names (bool):
+            Whether to randomize tip names or name them in order.
 
         verbose (bool):
             Print some useful information

--- a/toytree/Randomtree.py
+++ b/toytree/Randomtree.py
@@ -265,8 +265,6 @@ class RandomTree(object):
         verbose (bool):
             Print some useful information
         """
-        assert b <= 1, "birth rate should be between 0-1"
-        assert d <= 1, "death rate should be between 0-1"
 
         # set random seed
         if seed:

--- a/toytree/Randomtree.py
+++ b/toytree/Randomtree.py
@@ -265,6 +265,8 @@ class RandomTree(object):
         verbose (bool):
             Print some useful information
         """
+        if stop not in ["taxa", "time"]:
+            raise ToytreeError("stop must be either 'taxa' or 'time'")
 
         # set random seed
         if seed:
@@ -365,9 +367,12 @@ class RandomTree(object):
             for x in tips:
                 x.dist += dt
 
-            # time stopping criterion... not quite working right.
-            if maxtime:
-                if t >= maxtime:
+            # check stopping criterion
+            if stop == "taxa":
+                if len(tips) >= taxa_stop:
+                    break
+            else:
+                if t >= time_stop:
                     break
 
             # ntips stopping criterion.


### PR DESCRIPTION
Slightly changed the interface. Implemented an explicit stopping criterion to allow specifying either `ntips` or `time` as the quantity of interest for simulation. Removed the assert on the `b` and `d` params because these are rates per unit time, not proportions, so they can take any positive value.