### PR TITLE
Issue 26

### DIFF
--- a/toytree/Toytree.py
+++ b/toytree/Toytree.py
@@ -868,6 +868,23 @@ class ToyTree(object):
     #     return nself        
 
 
+    def generate_axes(self, firstname=None, lastname=None, axes=None, color="green", opacity=.25):
+        """
+        Returns an updated axes with a generated rectangle based on input labels provided
+        """
+        index_of_first = self.get_mrca_idx_from_tip_labels(names=firstname)
+        index_of_last =  self.get_mrca_idx_from_tip_labels(names=lastname)
+        x_vals = (x[0] for x in self.get_node_coordinates())
+
+        axes.rectangle(
+            min(self.get_tip_coordinates()[index_of_first][0],  self.get_tip_coordinates()[index_of_last][0]),
+            max(x_vals),
+            self.get_tip_coordinates()[index_of_first][1],
+            self.get_tip_coordinates()[index_of_last][1],
+            opacity=opacity,
+            color=color,
+        )
+        return axes
 
     def unroot(self):
         """

--- a/toytree/Toytree.py
+++ b/toytree/Toytree.py
@@ -868,7 +868,7 @@ class ToyTree(object):
     #     return nself        
 
 
-    def generate_axes(self, firstname=None, lastname=None, axes=None, color="green", opacity=.25):
+    def generate_rectangle(self, firstname=None, lastname=None, axes=None, color="green", opacity=.25):
         """
         Returns an updated axes with a generated rectangle based on input labels provided
         """


### PR DESCRIPTION
This is an attempt at addressing the enhancement suggested on #26 . This allows for drawing an opaque rectangle around a clade by specifying 2 tip label names. 
I am open to any suggestions to get this merged in.
