### PR TITLE
Added custom root option for parsing networks

### DIFF
--- a/toytree/utils.py
+++ b/toytree/utils.py
@@ -133,6 +133,8 @@ def parse_network(net, disconnect=True, root=None):
     Parse network to extract the major topology. 
     This leaves the hybrid nodes in the tree and labels each with 
     .name="H{int}" and .gamma={float}.
+    root: list of tip names used to root the tree. If "None" then roots on a
+    random tip.
     """
     # if net is a file then read the first line
     if os.path.exists(net):
@@ -160,6 +162,7 @@ def parse_network(net, disconnect=True, root=None):
     # store admix data
     admix = {}
 
+    # root on tips if provided by user -- otherwise pick a non-H root
     if not root:
         # if not rooted choose any non-H root
         if not net.is_rooted():

--- a/toytree/utils.py
+++ b/toytree/utils.py
@@ -128,7 +128,7 @@ NW_FORMAT = {
 
 
 
-def parse_network(net, disconnect=True):
+def parse_network(net, disconnect=True, root=None):
     """
     Parse network to extract the major topology. 
     This leaves the hybrid nodes in the tree and labels each with 
@@ -160,11 +160,14 @@ def parse_network(net, disconnect=True):
     # store admix data
     admix = {}
 
-    # if not rooted choose any non-H root
-    if not net.is_rooted():
-        net = net.root(
-            [i for i in net.get_tip_labels() if not i.startswith("#H")][0]
-        )
+    if not root:
+        # if not rooted choose any non-H root
+        if not net.is_rooted():
+            net = net.root(
+                [i for i in net.get_tip_labels() if not i.startswith("#H")][0]
+            )
+    else:
+        net = net.root(root)
 
     # Traverse tree to find hybrid nodes. If a hybrid node is labeled as a 
     # distinct branch in the tree then it is dropped from the tree and 


### PR DESCRIPTION
Without a custom root option the "admix" dict source/dest values can contain non-monophyletic groups after rerooting, making it difficult to relocate the node index after rerooting (which you could otherwise easily find by using `get_mrca_idx_from_tip_labels`). The custom option allows you to reroot how you want upon reading the tree so that the admix dict values will be monophyletic under that rooting. 