### PR TITLE
removed error message for prune function

### DIFF
--- a/toytree/core/tree.py
+++ b/toytree/core/tree.py
@@ -821,9 +821,6 @@ class ToyTree:
         nas = NodeAssist(nself, names, wildcard, regex)
         tipnames = nas.get_tipnames()
 
-        if len(tipnames) == len(nself):
-            raise ToytreeError("You cannot drop all tips from the tree.")
-
         if not tipnames:
             raise ToytreeError("No tips selected.")
 


### PR DESCRIPTION
Error was raised when all tips on the tree are provided to the function. I think this is just a holdover from the drop_tips function. When pruning, providing all of the tips should just return back the whole tree.