### PR TITLE
remove rU as it's deprecated

### DIFF
--- a/toytree/TreeParser.py
+++ b/toytree/TreeParser.py
@@ -133,7 +133,7 @@ class TreeParser(object):
 
             # is a file: read by lines to a list
             elif os.path.exists(self.intree):
-                with open(self.intree, 'rU') as indata:
+                with open(self.intree, 'r') as indata:
                     self.data = indata.readlines()
 
             # is a string: make into a list by splitting


### PR DESCRIPTION
The argument 'rU' in `open` to open a file with universal newlines was deprecated in python 3 as this is behaviour is now the default in py3. Therefore trying to read a file with mode='rU' will now raise an error. 

This PR removes 'rU' , but probably also breaks python 2 compatibility.