### PR TITLE
fix ValueError if there is no support value for a node (e.g. the root)

### DIFF
--- a/toytree/io/src/newick.py
+++ b/toytree/io/src/newick.py
@@ -359,7 +359,10 @@ def _check_internal_label_for_name_or_support(
     if internal_labels == "support":
         for idx in range(tree.ntips, tree.nnodes):
             node = tree[idx]
-            node.support = float(node.name)
+            if node.name:
+                node.support = float(node.name)
+            else:  # could not convert '' to float in nodes without support
+                node.support = 0.
             node.name = ""
 
     # NOTE: first written to not check the root b/c root might not 


### PR DESCRIPTION
The error was triggered by the tree string generated by typical tools (e.g. RAxML):

```python
import toytree
tre = toytree.io.parse_newick_string("((A:0.1,B:0.2)100,C:0.3,D:0.4);", internal_labels="support")
```
generated
```python
---> 362 node.support = float(node.name)
ValueError: could not convert string to float: ''
```

