### PR TITLE
Fixed bug for visualizations using layout 'd'

### DIFF
--- a/toytree/Coords.py
+++ b/toytree/Coords.py
@@ -278,7 +278,7 @@ class Coords:
             tmp = verts
 
         # right-facing tips align at x=0, last ladderized tip at y=0
-        if layout == 'r':
+        elif layout == 'r':
             # verts swap x and ys and make xs 0 to negative
             tmp = np.zeros(verts.shape)
             tmp[:, 1] = verts[:, 0]


### PR DESCRIPTION
Commit 09a02b6885064df617a55183577efca291f00ccf broke visualizations using layout 'd' due to change from an elif to an if statement.  This resulted in visualizations with tree_style = 'c' looking like

```
example2_newick = "((A:3, B:3):1, ((C:1, D:1):2, E:3):1);"
example2_tree = toytree.tree(example2_newick)
example2_tree.draw(tree_style="c", tip_labels=True, node_labels=False);
```

<img width="342" alt="Screenshot 2023-10-22 at 8 44 38 AM" src="https://github.com/eaton-lab/toytree/assets/593105/dd3f6233-adaf-4f17-b5fe-27f780139877">

This pull request reverts the bug-creating elif->if change.