### PR TITLE
limit mtree grid plotting to size of tree list

### DIFF
--- a/toytree/core/multitree.py
+++ b/toytree/core/multitree.py
@@ -562,7 +562,8 @@ class MultiTree:
             axes = grid.axes[idx]
 
             # add the mark
-            _, _, mark = treelist[idx].draw(axes=axes, **tmpargs)
+            if idx < len( treelist ) :
+                _, _, mark = treelist[idx].draw(axes=axes, **tmpargs)
 
             # store the mark
             marks.append(mark)


### PR DESCRIPTION
Sometimes, the user may want to plot a grid of trees that doesn't neatly fill an out `nrows` by `ncols` grid. For such cases, I think it's fine to leave the last few cells of the grid empty.