### PR TITLE
restructured, simple tests for quadripartitions

### DIFF
--- a/docs/quadripartitions.ipynb
+++ b/docs/quadripartitions.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quadripartition methods  \n",
+    "\n",
+    "\n",
+    "The `iter_quadripartitions()` function in the `.enum` subpackage returns all possible quadripartitions of a tree. Quadripartitions are defined by an internal `focal edge`, from which the tree is split into four partitions. Each partition stems from the children of the 2 nodes on either side of the `focal edge`. The quadripartitions are yielded in Node idxorder traversal in a nested format: a tuple of two tuples of two sets, e.g. `(({e0},{e1}), ({e2},{e3}))`, with the contents representing the tip Nodes descending from each of the four partition stems. In this example, `e0` through `e3` are the partition stems and are each children of the nodes being split along the `focal edge`. The order in which the partitions of a particular quadripartition are ordered is (child-left, child-right, sister, up) in relation to the Node directly below the `focal edge`.\n",
+    "\n",
+    "Note: Sets are used by default, which means when there are multiple nodes in a partition, they will not be sorted. This can be modified by using an ordered datatype like `type=tuple` or `type=list`. This will sort the nodes in alphabetical or index order (depending on whether `feature=\"name\"` or `feature=\"idx\"`.)\n",
+    "\n",
+    "### Simple example\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(({'a'}, {'b'}), ({'d', 'c'}, {'e'}))\n",
+      "(({'c'}, {'d'}), ({'e'}, {'b', 'a'}))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"toyplot\" id=\"t2bed18c748234eaa857692327350b70d\" style=\"text-align:center\"><svg class=\"toyplot-canvas-Canvas\" xmlns:toyplot=\"http://www.sandia.gov/toyplot\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns=\"http://www.w3.org/2000/svg\" width=\"300.0px\" height=\"275.0px\" viewBox=\"0 0 300.0 275.0\" preserveAspectRatio=\"xMidYMid meet\" style=\"background-color:transparent;border-color:#292724;border-style:none;border-width:1.0;fill:rgb(16.1%,15.3%,14.1%);fill-opacity:1.0;font-family:Helvetica;font-size:12px;opacity:1.0;stroke:rgb(16.1%,15.3%,14.1%);stroke-opacity:1.0;stroke-width:1.0\" id=\"t596e723ed626476d9b65d14dd7717ad3\"><g class=\"toyplot-coordinates-Cartesian\" id=\"t68145f7a76d94583ba0a5d7fd663cc07\"><clipPath id=\"t2e67983249d9461e9710d41a35fd0f91\"><rect x=\"35.0\" y=\"35.0\" width=\"230.0\" height=\"205.0\"></rect></clipPath><g clip-path=\"url(#t2e67983249d9461e9710d41a35fd0f91)\"><g class=\"toytree-mark-Toytree\" id=\"tcfbead19b113432a8ee7571f3513548e\"><g class=\"toytree-Edges\" style=\"stroke:rgb(14.5%,14.5%,14.5%);stroke-opacity:1.0;stroke-linecap:round;stroke-width:2.0;fill:none\"><path d=\"M 114.0 196.7 L 114.0 216.4 L 164.7 216.4\" id=\"5,0\" style=\"\"></path><path d=\"M 114.0 196.7 L 114.0 177.0 L 164.7 177.0\" id=\"5,1\" style=\"\"></path><path d=\"M 164.7 117.8 L 164.7 137.5 L 215.4 137.5\" id=\"6,2\" style=\"\"></path><path d=\"M 164.7 117.8 L 164.7 98.0 L 215.4 98.0\" id=\"6,3\" style=\"\"></path><path d=\"M 114.0 88.2 L 114.0 58.6 L 164.7 58.6\" id=\"7,4\" style=\"\"></path><path d=\"M 63.3 142.4 L 63.3 196.7 L 114.0 196.7\" id=\"8,5\" style=\"\"></path><path d=\"M 114.0 88.2 L 114.0 117.8 L 164.7 117.8\" id=\"7,6\" style=\"\"></path><path d=\"M 63.3 142.4 L 63.3 88.2 L 114.0 88.2\" id=\"8,7\" style=\"\"></path></g><g class=\"toytree-AdmixEdges\" style=\"fill:rgb(0.0%,0.0%,0.0%);fill-opacity:0.0;stroke:rgb(90.6%,54.1%,76.5%);stroke-opacity:0.6;font-size:14px;stroke-linecap:round;stroke-width:5\"></g><g class=\"toytree-Nodes\" style=\"fill:rgb(82.7%,82.7%,82.7%);fill-opacity:1.0;stroke:rgb(14.9%,14.9%,14.9%);stroke-opacity:1.0;stroke-width:1.5\"><g id=\"Node-5\" transform=\"translate(113.989,196.698)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-6\" transform=\"translate(164.673,117.767)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-7\" transform=\"translate(113.989,88.1685)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-8\" transform=\"translate(63.3045,142.433)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g></g><g class=\"toytree-NodeLabels\" style=\"font-family:Helvetica;font-size:9px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-NodeLabel\" transform=\"translate(113.989,196.698)\"><text x=\"-3.0015\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">X</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(164.673,117.767)\"><text x=\"-3.0015\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Y</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(113.989,88.1685)\"><text x=\"-2.7495\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Z</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(63.3045,142.433)\"><text x=\"-3.249\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">R</text></g></g><g class=\"toytree-TipLabels\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0;font-family:Helvetica;font-size:14px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-TipLabel\" transform=\"translate(164.673,216.43)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">a</text></g><g class=\"toytree-TipLabel\" transform=\"translate(164.673,176.965)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">b</text></g><g class=\"toytree-TipLabel\" transform=\"translate(215.356,137.5)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">c</text></g><g class=\"toytree-TipLabel\" transform=\"translate(215.356,98.0348)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">d</text></g><g class=\"toytree-TipLabel\" transform=\"translate(164.673,58.5696)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">e</text></g></g></g></g></g></svg><div class=\"toyplot-behavior\"><script>(function()\n",
+       "{\n",
+       "var modules={};\n",
+       "})();</script></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import toytree  \n",
+    "\n",
+    "#define tree with simple Newick string\n",
+    "newick = \"((a,b)X,((c,d)Y,e)Z)R;\" \n",
+    "tree = toytree.tree(newick)  \n",
+    "\n",
+    "tree.draw('r'); #draw tree in R-style\n",
+    "\n",
+    "#iteratively return all quadripartitions in phylogenetic tree\n",
+    "for q in toytree.enum.iter_quadripartitions(tree):\n",
+    "    print(q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, the only internal edges available to make quadripartitions from are the edges directly above `Y` and `Z` (or `X`, but it has the same result as `Z`). These two quadripartitions are given in tuples of tuples of sets to denotate the first (tuple) and second (sets) bipartitions that create the quadripartition."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sorting and formatting  \n",
+    "\n",
+    "\n",
+    "When `type=` is set to an ordered datatype (i.e. tuple, list), `iter_quadripartitions` will automatically sort the values within each partition. The user can choose to sort the quadripartition further, ordering each partition within its bipartitions and each bipartition within its quadripartition, by using `sort=True`. This first orders them in size order (small to large), and if the sizes are equal, then by the lowest value Node present."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(((2,), (3,)), ((4, 5, 7), (0, 1))), (((4,), (5,)), ((2, 3, 6), (0, 1))), (((2, 3, 6), (4, 5, 7)), ((0,), (1,)))]\n",
+      "[(((2,), (3,)), ((0, 1), (4, 5, 7))), (((4,), (5,)), ((0, 1), (2, 3, 6))), (((0,), (1,)), ((2, 3, 6), (4, 5, 7)))]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"toyplot\" id=\"tabf2b792990a446896b37d14bd43415e\" style=\"text-align:center\"><svg class=\"toyplot-canvas-Canvas\" xmlns:toyplot=\"http://www.sandia.gov/toyplot\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns=\"http://www.w3.org/2000/svg\" width=\"300.0px\" height=\"275.0px\" viewBox=\"0 0 300.0 275.0\" preserveAspectRatio=\"xMidYMid meet\" style=\"background-color:transparent;border-color:#292724;border-style:none;border-width:1.0;fill:rgb(16.1%,15.3%,14.1%);fill-opacity:1.0;font-family:Helvetica;font-size:12px;opacity:1.0;stroke:rgb(16.1%,15.3%,14.1%);stroke-opacity:1.0;stroke-width:1.0\" id=\"td5ea2b4481a34fb0882b8a0704ca42aa\"><g class=\"toyplot-coordinates-Cartesian\" id=\"t64056e69b5c44234b1c5e086a9438b18\"><clipPath id=\"td45439954d5a4d80afa1e9176e676f01\"><rect x=\"35.0\" y=\"35.0\" width=\"230.0\" height=\"205.0\"></rect></clipPath><g clip-path=\"url(#td45439954d5a4d80afa1e9176e676f01)\"><g class=\"toytree-mark-Toytree\" id=\"t1ac8e0b4120d4a00b66fd9dd15d433f3\"><g class=\"toytree-Edges\" style=\"stroke:rgb(14.5%,14.5%,14.5%);stroke-opacity:1.0;stroke-linecap:round;stroke-width:2.0;fill:none\"><path d=\"M 50.8 169.8 L 50.8 218.3 L 105.4 218.3\" id=\"9,0\" style=\"\"></path><path d=\"M 50.8 169.8 L 50.8 186.0 L 105.4 186.0\" id=\"9,1\" style=\"\"></path><path d=\"M 160.0 137.5 L 160.0 153.7 L 214.5 153.7\" id=\"6,2\" style=\"\"></path><path d=\"M 160.0 137.5 L 160.0 121.3 L 214.5 121.3\" id=\"6,3\" style=\"\"></path><path d=\"M 160.0 72.8 L 160.0 89.0 L 214.5 89.0\" id=\"7,4\" style=\"\"></path><path d=\"M 160.0 72.8 L 160.0 56.7 L 214.5 56.7\" id=\"7,5\" style=\"\"></path><path d=\"M 105.4 105.2 L 105.4 137.5 L 160.0 137.5\" id=\"8,6\" style=\"\"></path><path d=\"M 105.4 105.2 L 105.4 72.8 L 160.0 72.8\" id=\"8,7\" style=\"\"></path><path d=\"M 50.8 169.8 L 50.8 105.2 L 105.4 105.2\" id=\"9,8\" style=\"\"></path></g><g class=\"toytree-AdmixEdges\" style=\"fill:rgb(0.0%,0.0%,0.0%);fill-opacity:0.0;stroke:rgb(90.6%,54.1%,76.5%);stroke-opacity:0.6;font-size:14px;stroke-linecap:round;stroke-width:5\"></g><g class=\"toytree-Nodes\" style=\"fill:rgb(40.0%,76.1%,64.7%);fill-opacity:1.0;stroke:rgb(14.9%,14.9%,14.9%);stroke-opacity:1.0;stroke-width:1.5\"></g><g class=\"toytree-TipLabels\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0;font-family:Helvetica;font-size:12px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-TipLabel\" transform=\"translate(105.386,218.347)\"><text x=\"15.0\" y=\"3.066\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">a</text></g><g class=\"toytree-TipLabel\" transform=\"translate(105.386,186.008)\"><text x=\"15.0\" y=\"3.066\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">b</text></g><g class=\"toytree-TipLabel\" transform=\"translate(214.522,153.669)\"><text x=\"15.0\" y=\"3.066\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">c</text></g><g class=\"toytree-TipLabel\" transform=\"translate(214.522,121.331)\"><text x=\"15.0\" y=\"3.066\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">d</text></g><g class=\"toytree-TipLabel\" transform=\"translate(214.522,88.9916)\"><text x=\"15.0\" y=\"3.066\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">e</text></g><g class=\"toytree-TipLabel\" transform=\"translate(214.522,56.6526)\"><text x=\"15.0\" y=\"3.066\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">f</text></g></g></g></g></g></svg><div class=\"toyplot-behavior\"><script>(function()\n",
+       "{\n",
+       "var modules={};\n",
+       "})();</script></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#build tree from simple newick string and visualize it\n",
+    "tree = toytree.tree(\"(a,b,((c,d)CD,(e,f)EF)X)AB;\") \n",
+    "tree.draw()\n",
+    "\n",
+    "#return quadripartitions as list, with each partition returned in a tuple (instead of a set), including the internal nodes of each partition\n",
+    "unordered = list(tree.enum.iter_quadripartitions(type=tuple, \n",
+    "                                                 include_internal_nodes=True, \n",
+    "                                                 feature=\"idx\"))\n",
+    "ordered = list(tree.enum.iter_quadripartitions(type=tuple, \n",
+    "                                               include_internal_nodes=True, \n",
+    "                                               feature=\"idx\", \n",
+    "                                               sort=True))\n",
+    "print(unordered)\n",
+    "print(ordered)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The user can also choose to return more or less information about each quadripartition, ranging from all tips and internal nodes using `include_internal_nodes=True`, to only the stems of each partition (`contract_partitions=True`). To specify what information is returned, use the `feature=` argument with any available Node feature. \n",
+    "\n",
+    "### Example  \n",
+    "\n",
+    "#### Lots of information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(({'alfred'}, {'bob'}), ({'david', 'Yasmin', 'cindy'}, {'ellis'}))\n",
+      "(({'cindy'}, {'david'}), ({'ellis'}, {'bob', 'Xiang', 'alfred'}))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"toyplot\" id=\"t39869160ab31478ebd1ed8123b7378c1\" style=\"text-align:center\"><svg class=\"toyplot-canvas-Canvas\" xmlns:toyplot=\"http://www.sandia.gov/toyplot\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns=\"http://www.w3.org/2000/svg\" width=\"300.0px\" height=\"275.0px\" viewBox=\"0 0 300.0 275.0\" preserveAspectRatio=\"xMidYMid meet\" style=\"background-color:transparent;border-color:#292724;border-style:none;border-width:1.0;fill:rgb(16.1%,15.3%,14.1%);fill-opacity:1.0;font-family:Helvetica;font-size:12px;opacity:1.0;stroke:rgb(16.1%,15.3%,14.1%);stroke-opacity:1.0;stroke-width:1.0\" id=\"tb0f64565d78745fe86dcd494d3a6ebd6\"><g class=\"toyplot-coordinates-Cartesian\" id=\"t691edd31825847ccac7d3dc47e4e4117\"><clipPath id=\"t28cf81246c0f4e159017bb57031b7581\"><rect x=\"35.0\" y=\"35.0\" width=\"230.0\" height=\"205.0\"></rect></clipPath><g clip-path=\"url(#t28cf81246c0f4e159017bb57031b7581)\"><g class=\"toytree-mark-Toytree\" id=\"te2fb2239de8d4ab7bff836cb6da51c39\"><g class=\"toytree-Edges\" style=\"stroke:rgb(14.5%,14.5%,14.5%);stroke-opacity:1.0;stroke-linecap:round;stroke-width:2.0;fill:none\"><path d=\"M 103.5 196.7 L 103.5 216.4 L 145.9 216.4\" id=\"5,0\" style=\"\"></path><path d=\"M 103.5 196.7 L 103.5 177.0 L 145.9 177.0\" id=\"5,1\" style=\"\"></path><path d=\"M 145.9 117.8 L 145.9 137.5 L 188.3 137.5\" id=\"6,2\" style=\"\"></path><path d=\"M 145.9 117.8 L 145.9 98.0 L 188.3 98.0\" id=\"6,3\" style=\"\"></path><path d=\"M 103.5 88.2 L 103.5 58.6 L 145.9 58.6\" id=\"7,4\" style=\"\"></path><path d=\"M 61.1 142.4 L 61.1 196.7 L 103.5 196.7\" id=\"8,5\" style=\"\"></path><path d=\"M 103.5 88.2 L 103.5 117.8 L 145.9 117.8\" id=\"7,6\" style=\"\"></path><path d=\"M 61.1 142.4 L 61.1 88.2 L 103.5 88.2\" id=\"8,7\" style=\"\"></path></g><g class=\"toytree-AdmixEdges\" style=\"fill:rgb(0.0%,0.0%,0.0%);fill-opacity:0.0;stroke:rgb(90.6%,54.1%,76.5%);stroke-opacity:0.6;font-size:14px;stroke-linecap:round;stroke-width:5\"></g><g class=\"toytree-Nodes\" style=\"fill:rgb(82.7%,82.7%,82.7%);fill-opacity:1.0;stroke:rgb(14.9%,14.9%,14.9%);stroke-opacity:1.0;stroke-width:1.5\"><g id=\"Node-5\" transform=\"translate(103.538,196.698)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-6\" transform=\"translate(145.944,117.767)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-7\" transform=\"translate(103.538,88.1685)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-8\" transform=\"translate(61.1316,142.433)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g></g><g class=\"toytree-NodeLabels\" style=\"font-family:Helvetica;font-size:9px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-NodeLabel\" transform=\"translate(103.538,196.698)\"><text x=\"-11.5065\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Xiang</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(145.944,117.767)\"><text x=\"-15.003\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Yasmin</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(103.538,88.1685)\"><text x=\"-9.252\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Zoro</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(61.1316,142.433)\"><text x=\"-13.005\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Randy</text></g></g><g class=\"toytree-TipLabels\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0;font-family:Helvetica;font-size:14px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-TipLabel\" transform=\"translate(145.944,216.43)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">alfred</text></g><g class=\"toytree-TipLabel\" transform=\"translate(145.944,176.965)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">bob</text></g><g class=\"toytree-TipLabel\" transform=\"translate(188.35,137.5)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">cindy</text></g><g class=\"toytree-TipLabel\" transform=\"translate(188.35,98.0348)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">david</text></g><g class=\"toytree-TipLabel\" transform=\"translate(145.944,58.5696)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">ellis</text></g></g></g></g></g></svg><div class=\"toyplot-behavior\"><script>(function()\n",
+       "{\n",
+       "var modules={};\n",
+       "})();</script></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import toytree  \n",
+    "\n",
+    "#define tree with simple Newick string\n",
+    "newick = \"((alfred,bob)Xiang,((cindy,david)Yasmin,ellis)Zoro)Randy;\" \n",
+    "tree = toytree.tree(newick)  \n",
+    "\n",
+    "tree.draw('r'); #draw tree in R-style\n",
+    "\n",
+    "\n",
+    "for q in toytree.enum.iter_quadripartitions(tree, \n",
+    "                                            include_internal_nodes=True, \n",
+    "                                            feature=\"name\"):\n",
+    "    print(q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Little information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(({0}, {1}), ({6}, {4}))\n",
+      "(({2}, {3}), ({7}, {4}))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"toyplot\" id=\"t956b690187644c50b4aa2183ffc9a224\" style=\"text-align:center\"><svg class=\"toyplot-canvas-Canvas\" xmlns:toyplot=\"http://www.sandia.gov/toyplot\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns=\"http://www.w3.org/2000/svg\" width=\"300.0px\" height=\"275.0px\" viewBox=\"0 0 300.0 275.0\" preserveAspectRatio=\"xMidYMid meet\" style=\"background-color:transparent;border-color:#292724;border-style:none;border-width:1.0;fill:rgb(16.1%,15.3%,14.1%);fill-opacity:1.0;font-family:Helvetica;font-size:12px;opacity:1.0;stroke:rgb(16.1%,15.3%,14.1%);stroke-opacity:1.0;stroke-width:1.0\" id=\"tb5161b7e573f469c9ae523e755f4c91d\"><g class=\"toyplot-coordinates-Cartesian\" id=\"t67ed725525b64babb01471fe97555803\"><clipPath id=\"tc27c6b6b8e0d421f832ba211cb44d13f\"><rect x=\"35.0\" y=\"35.0\" width=\"230.0\" height=\"205.0\"></rect></clipPath><g clip-path=\"url(#tc27c6b6b8e0d421f832ba211cb44d13f)\"><g class=\"toytree-mark-Toytree\" id=\"tdc67e38619fd476b87fee675a600934b\"><g class=\"toytree-Edges\" style=\"stroke:rgb(14.5%,14.5%,14.5%);stroke-opacity:1.0;stroke-linecap:round;stroke-width:2.0;fill:none\"><path d=\"M 103.5 196.7 L 103.5 216.4 L 145.9 216.4\" id=\"5,0\" style=\"\"></path><path d=\"M 103.5 196.7 L 103.5 177.0 L 145.9 177.0\" id=\"5,1\" style=\"\"></path><path d=\"M 145.9 117.8 L 145.9 137.5 L 188.3 137.5\" id=\"6,2\" style=\"\"></path><path d=\"M 145.9 117.8 L 145.9 98.0 L 188.3 98.0\" id=\"6,3\" style=\"\"></path><path d=\"M 103.5 88.2 L 103.5 58.6 L 145.9 58.6\" id=\"7,4\" style=\"\"></path><path d=\"M 61.1 142.4 L 61.1 196.7 L 103.5 196.7\" id=\"8,5\" style=\"\"></path><path d=\"M 103.5 88.2 L 103.5 117.8 L 145.9 117.8\" id=\"7,6\" style=\"\"></path><path d=\"M 61.1 142.4 L 61.1 88.2 L 103.5 88.2\" id=\"8,7\" style=\"\"></path></g><g class=\"toytree-AdmixEdges\" style=\"fill:rgb(0.0%,0.0%,0.0%);fill-opacity:0.0;stroke:rgb(90.6%,54.1%,76.5%);stroke-opacity:0.6;font-size:14px;stroke-linecap:round;stroke-width:5\"></g><g class=\"toytree-Nodes\" style=\"fill:rgb(82.7%,82.7%,82.7%);fill-opacity:1.0;stroke:rgb(14.9%,14.9%,14.9%);stroke-opacity:1.0;stroke-width:1.5\"><g id=\"Node-5\" transform=\"translate(103.538,196.698)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-6\" transform=\"translate(145.944,117.767)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-7\" transform=\"translate(103.538,88.1685)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g><g id=\"Node-8\" transform=\"translate(61.1316,142.433)\"><rect x=\"-16.0\" y=\"-8.0\" width=\"32.0\" height=\"16.0\"></rect></g></g><g class=\"toytree-NodeLabels\" style=\"font-family:Helvetica;font-size:9px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-NodeLabel\" transform=\"translate(103.538,196.698)\"><text x=\"-11.5065\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Xiang</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(145.944,117.767)\"><text x=\"-15.003\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Yasmin</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(103.538,88.1685)\"><text x=\"-9.252\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Zoro</text></g><g class=\"toytree-NodeLabel\" transform=\"translate(61.1316,142.433)\"><text x=\"-13.005\" y=\"2.2995\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">Randy</text></g></g><g class=\"toytree-TipLabels\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0;font-family:Helvetica;font-size:14px;font-weight:300;vertical-align:baseline;white-space:pre;stroke:none\"><g class=\"toytree-TipLabel\" transform=\"translate(145.944,216.43)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">alfred</text></g><g class=\"toytree-TipLabel\" transform=\"translate(145.944,176.965)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">bob</text></g><g class=\"toytree-TipLabel\" transform=\"translate(188.35,137.5)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">cindy</text></g><g class=\"toytree-TipLabel\" transform=\"translate(188.35,98.0348)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">david</text></g><g class=\"toytree-TipLabel\" transform=\"translate(145.944,58.5696)\"><text x=\"15.0\" y=\"3.577\" style=\"fill:rgb(14.5%,14.5%,14.5%);fill-opacity:1.0\">ellis</text></g></g></g></g></g></svg><div class=\"toyplot-behavior\"><script>(function()\n",
+       "{\n",
+       "var modules={};\n",
+       "})();</script></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import toytree  \n",
+    "\n",
+    "#define tree with simple Newick string\n",
+    "newick = \"((alfred,bob)Xiang,((cindy,david)Yasmin,ellis)Zoro)Randy;\" \n",
+    "tree = toytree.tree(newick)  \n",
+    "\n",
+    "tree.draw('r'); #draw tree in R-style\n",
+    "\n",
+    "\n",
+    "for q in toytree.enum.iter_quadripartitions(tree, \n",
+    "                                            contract_partitions=True, \n",
+    "                                            feature=\"idx\", \n",
+    "                                            sort=True):\n",
+    "    print(q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both of these quadripartition sets represent the same quadripartitions from the same tree, just expressed in different formats."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "toytree_practice",
+   "language": "python",
+   "name": "toytree_practice"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,7 +113,7 @@ nav:
     - <i>.enum</i> - tree enumeration:
       - bipartition methods: bipartitions.ipynb
       - quartet methods: quartets.ipynb
-      - quadripartition methods: ...
+      - quadripartition methods: quadripartitions.ipnyb
       # - other: ...
 
     - <i>.distance</i> - tree/node dists:

--- a/toytree/enum/src/quadripartitions.py
+++ b/toytree/enum/src/quadripartitions.py
@@ -423,34 +423,40 @@ if __name__ == "__main__":
 
     import toytree
 
-    newick = "((a,b)X,((c,d)Y,e)Z)R;"
-    tree = toytree.tree(newick).root("c")
+    # newick = "((a,b)X,((c,d)Y,e)Z)R;"
+    # tree = toytree.tree(newick).root("c")
 
     # tree = toytree.rtree.baltree(12, seed=1234).unroot()
     tree = toytree.tree("(a,b,((c,d)CD,(e,f)EF)X)AB;")
+
+    results = iter_quadripartitions(tree, type=list, sort=True, include_internal_nodes=True)
+    
+    for item in results:
+        print(item[1][0][0])
+
     # tree._draw_browser(ts='r')
     # for bipart in _iter_quadripartition_sets(tree, include_internal_nodes=True):
     # for part in iter_quadripartitions(tree,):
     # print(part)
 
     # args to get consistently sorted biparts regardless of rooting
-    tree = tree.root("X")
-    for i in sorted(iter_quadripartitions(tree, type=set, sort=True)):
-        print(i)
+    # tree = tree.root("X")
+    # for i in sorted(iter_quadripartitions(tree, type=set, sort=True)):
+    #     print(i)
     # [(('a', 'b'), ('c', 'd', 'e', 'f')),
     #  (('c', 'd'), ('a', 'b', 'e', 'f')),
     #  (('e', 'f'), ('a', 'b', 'c', 'd'))]
 
 
-    tree = tree.root("X")
-    for i in sorted(iter_quadripartitions(tree, sort=True, collapse=True)):
-        print(i)
+    # tree = tree.root("X")
+    # for i in sorted(iter_quadripartitions(tree, sort=True, collapse=True)):
+    #     print(i)
 
 
     # convert consistent bipartitions to sets for easy comparison
-    x = set(tree.root('a').enum.iter_quadripartitions(type=tuple, sort=True))
-    y = set(tree.root('e').enum.iter_quadripartitions(type=tuple, sort=True))
-    assert x == y
+    # x = set(tree.root('a').enum.iter_quadripartitions(type=tuple, sort=True))
+    # y = set(tree.root('e').enum.iter_quadripartitions(type=tuple, sort=True))
+    # assert x == y
 
     # tree = toytree.rtree.unittree(6, seed=123).unroot()
     # c1, *_ = tree.draw('p')

--- a/toytree/enum/tests/test_quadripartitions.py
+++ b/toytree/enum/tests/test_quadripartitions.py
@@ -68,9 +68,7 @@ class TestQuartets(unittest.TestCase):
         self.trees = [self.tree1, self.tree2]
 
     def _test_sorting(self, results, collapse: bool = False, sort: bool = False):
-        """Helper function to test sorting of quartets.
-        Tests both the automatic sorting method on the tip-level pairs
-        and the sort= argument at the quartet-level"""
+        """Helper function to test sorting of quadripartitions."""
         for item in results: 
             if not isinstance(item[0], set):
                 if collapse:
@@ -83,7 +81,7 @@ class TestQuartets(unittest.TestCase):
                         self.assertGreater(item[0][1][0], item[0][0][0])  #quartet-level sorting (x,y),(i,j) -> (i,j),(x,y)
 
 
-    def test_default(self):
+    def test_default(self): #testing default behavior (set) 
         results = list(iter_quadripartitions(self.tree1))
         self.assertIsInstance(results[0][0], tuple)
         self.assertIsInstance(results[0][0][0], set)


### PR DESCRIPTION
restructured tests to capture a decent range of all of the possible arguments. The only lines changed in quadripartitions.py were in main and did not affect the actual functional code at all. 