### PR TITLE
Add unit tests for discrete Markov model (ER Q-matrix & seed reproducibility)

### DIFF
--- a/toytree/pcm/_tests/test_discrete_markov_model_sim.py
+++ b/toytree/pcm/_tests/test_discrete_markov_model_sim.py
@@ -1,0 +1,31 @@
+import unittest
+
+import numpy as np
+
+from toytree.pcm.src.traits.discrete_markov_model_sim import MarkovModel
+
+
+class TestDiscreteMarkovModelSim(unittest.TestCase):
+    def test_qmatrix_er_construction(self):
+        """Ensure ER model builds expected reversible Q matrix."""
+        model = MarkovModel(nstates=3, mtype="ER", rate_scalar=1.0)
+        expected = np.array(
+            [
+                [-2.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
+                [1.0 / 3.0, -2.0 / 3.0, 1.0 / 3.0],
+                [1.0 / 3.0, 1.0 / 3.0, -2.0 / 3.0],
+            ]
+        )
+        np.testing.assert_allclose(model.qmatrix, expected, rtol=1e-8, atol=1e-12)
+        np.testing.assert_allclose(model.transition_matrix, expected, rtol=1e-8, atol=1e-12)
+
+    def test_seed_reproducibility_for_parameters(self):
+        """Ensure seeded models produce identical random parameters."""
+        model_a = MarkovModel(nstates=4, mtype="SYM", seed=123)
+        model_b = MarkovModel(nstates=4, mtype="SYM", seed=123)
+        np.testing.assert_allclose(model_a.relative_rates, model_b.relative_rates)
+        np.testing.assert_allclose(model_a.state_frequencies, model_b.state_frequencies)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide automated coverage for the discrete Markov model implementation by validating ER Q-matrix construction and RNG-seeded parameter reproducibility.

### Description
- Add a new test module at `toytree/pcm/_tests/test_discrete_markov_model_sim.py` containing two unit tests that verify the ER `qmatrix`/`transition_matrix` and seeded equality of `relative_rates` and `state_frequencies`.
- The tests construct `MarkovModel` instances and compare numeric arrays with `numpy.testing.assert_allclose` using tight tolerances.

### Testing
- Ran the test module with `python -m unittest toytree.pcm._tests.test_discrete_markov_model_sim`, which executed 2 tests and returned `OK` (both tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862552e490832d9a0347efdab68a5e)