### PR TITLE
refine penalized likelihood ultrametric fitting

### DIFF
--- a/tests/cli/test_make_ultrametric_cli.py
+++ b/tests/cli/test_make_ultrametric_cli.py
@@ -22,7 +22,10 @@ from toytree.utils import ToytreeError
 
 
 class TestMakeUltrametricCLI(PytestCompat):
+    """CLI regression tests for make-ultrametric."""
+
     def setUp(self):
+        """Create a temporary non-ultrametric input tree."""
         self.tmpdir = Path(tempfile.mkdtemp(prefix="toytree-cli-make-ultrametric-"))
         self.tree_path = self.tmpdir / "tree.nwk"
         # non-ultrametric input
@@ -37,6 +40,7 @@ class TestMakeUltrametricCLI(PytestCompat):
         return stream.getvalue().strip()
 
     def test_extend_method_makes_tree_ultrametric(self):
+        """Extend mode should emit an ultrametric tree."""
         out_nwk = self._run_capture_stdout(
             ["-i", str(self.tree_path), "--method", "extend"]
         )
@@ -44,6 +48,7 @@ class TestMakeUltrametricCLI(PytestCompat):
         self.assertTrue(tree.is_ultrametric())
 
     def test_extend_method_full_flag_is_silently_ignored(self):
+        """Extend mode should ignore full summaries and just write the tree."""
         args = self.parser.parse_args(
             ["-i", str(self.tree_path), "--method", "extend", "--full"]
         )
@@ -83,15 +88,17 @@ class TestMakeUltrametricCLI(PytestCompat):
         payload = json.loads(err.getvalue().strip())
         self.assertEqual(payload["method"], "correlated")
 
-    def test_discrete_estimate_json_summary(self):
-        """Discrete estimate mode should emit search payload as JSON to stderr."""
+    def test_discrete_candidate_list_json_summary(self):
+        """Discrete candidate lists should emit search payload as JSON to stderr."""
         args = self.parser.parse_args(
             [
                 "-i",
                 str(self.tree_path),
                 "--method",
                 "discrete",
-                "--estimate",
+                "--ncat",
+                "1",
+                "2",
                 "3",
                 "--max-iter",
                 "200",
@@ -111,9 +118,10 @@ class TestMakeUltrametricCLI(PytestCompat):
         payload = json.loads(err.getvalue().strip())
         self.assertEqual(payload["method"], "discrete")
         self.assertIn("search", payload)
-        self.assertIn("estimated_parameter", payload)
+        self.assertIn("selected_ncategories", payload)
 
     def test_discrete_requires_ncategories(self):
+        """Discrete mode should require at least one ncategory value."""
         args = self.parser.parse_args(
             ["-i", str(self.tree_path), "--method", "discrete"]
         )
@@ -121,6 +129,7 @@ class TestMakeUltrametricCLI(PytestCompat):
             run_make_ultrametric(args)
 
     def test_lam_must_be_non_negative(self):
+        """Negative lambda values should be rejected."""
         args = self.parser.parse_args(
             ["-i", str(self.tree_path), "--method", "relaxed", "--lam", "-0.1"]
         )
@@ -128,6 +137,7 @@ class TestMakeUltrametricCLI(PytestCompat):
             run_make_ultrametric(args)
 
     def test_parse_calibrations_single_and_range(self):
+        """CLI calibration parsing should support fixed ages and ranges."""
         tree = toytree.tree("((a:1,b:1):1,c:1);")
         cals = _parse_calibrations(tree, ["-1=1.0", "a=0.1-0.2"])
         self.assertIn(tree[-1].idx, cals)
@@ -135,6 +145,7 @@ class TestMakeUltrametricCLI(PytestCompat):
         self.assertEqual(cals[tree[0].idx], (0.1, 0.2))
 
     def test_cli_calibrations_accept_negative_node_query_token(self):
+        """Negative node queries should be normalized before parsing."""
         argv = normalize_calibration_argv(
             ["-i", str(self.tree_path), "--method", "clock", "-c", "-1=1.0"]
         )
@@ -142,6 +153,7 @@ class TestMakeUltrametricCLI(PytestCompat):
         self.assertEqual(args.calibrations, [f"{NEGATIVE_CAL_QUERY_PREFIX}1=1.0"])
 
     def test_correlated_method_runs(self):
+        """Correlated PL mode should run and emit an ultrametric tree."""
         out_nwk = self._run_capture_stdout(
             [
                 "-i",
@@ -167,14 +179,17 @@ class TestMakeUltrametricCLI(PytestCompat):
         tree = toytree.tree(out_nwk)
         self.assertTrue(tree.is_ultrametric())
 
-    def test_discrete_estimate_runs_without_ncat(self):
+    def test_discrete_candidate_list_runs(self):
+        """Discrete candidate lists should select and emit one ultrametric tree."""
         out_nwk = self._run_capture_stdout(
             [
                 "-i",
                 str(self.tree_path),
                 "--method",
                 "discrete",
-                "--estimate",
+                "--ncat",
+                "1",
+                "2",
                 "3",
                 "--max-iter",
                 "200",
@@ -187,9 +202,9 @@ class TestMakeUltrametricCLI(PytestCompat):
         tree = toytree.tree(out_nwk)
         self.assertTrue(tree.is_ultrametric())
 
-    def test_estimate_invalid_for_clock(self):
-        args = self.parser.parse_args(
-            ["-i", str(self.tree_path), "--method", "clock", "--estimate", "3"]
-        )
-        with self.assertRaises(ToytreeError):
-            run_make_ultrametric(args)
+    def test_removed_estimate_flag_fails_at_parse_time(self):
+        """The removed estimate flag should be rejected by the parser."""
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(
+                ["-i", str(self.tree_path), "--method", "clock", "--estimate", "3"]
+            )

--- a/tests/mod/test_make_ultrametric_api.py
+++ b/tests/mod/test_make_ultrametric_api.py
@@ -1,55 +1,166 @@
 #!/usr/bin/env python
 
+from unittest.mock import patch
 
+import numpy as np
 from conftest import PytestCompat
+from scipy.special import gammaln
 
+import toytree
+from toytree.mod._src.penalized_likelihood import pl_clock
 from toytree.mod._src.penalized_likelihood.pl_utils import (
     get_tree_with_categorical_rates,
+    get_tree_with_correlated_relaxed_rates,
     get_tree_with_uncorrelated_relaxed_rates,
 )
 from toytree.utils import ToytreeError
 
 
 class TestMakeUltrametricAPI(PytestCompat):
-    def test_discrete_estimate_returns_best_and_search(self):
+    """Tests for the user-facing ultrametric wrapper API."""
+
+    def test_discrete_candidate_list_returns_best_and_search(self):
+        """Discrete candidate lists should expose PHIIC search metadata."""
         tree = get_tree_with_categorical_rates(ntips=10, nrates=2, seed=123)
         res = tree.mod.edges_make_ultrametric(
             method="discrete",
             calibrations={-1: 1.0},
-            estimate=4,
+            ncategories=[1, 2, 4],
             full=True,
             max_iter=500,
             max_fun=500,
             max_refine=2,
         )
-        self.assertEqual(res["estimated_parameter"], "ncategories")
-        self.assertIn("estimated_value", res)
-        self.assertTrue(len(res["search"]) >= 1)
+        self.assertEqual(res["selection_criterion"], "PHIIC")
+        self.assertIn("selected_ncategories", res)
+        self.assertEqual([i["candidate"] for i in res["search"]], [1, 2, 4])
         self.assertTrue(res["tree"].is_ultrametric())
 
-    def test_relaxed_estimate_returns_lam(self):
+    def test_removed_estimate_argument_raises_type_error(self):
+        """Legacy estimate argument should no longer be accepted."""
+        tree = get_tree_with_uncorrelated_relaxed_rates(
+            ntips=10, mean=3, sigma=3, seed=123
+        )
+        with self.assertRaises(TypeError):
+            tree.mod.edges_make_ultrametric(
+                method="relaxed",
+                calibrations={-1: 1.0},
+                estimate=3,
+                full=True,
+            )
+
+    def test_relaxed_rejects_ncategories_candidate_list(self):
+        """Only discrete mode should accept multiple ncategory candidates."""
+        tree = get_tree_with_uncorrelated_relaxed_rates(
+            ntips=10, mean=3, sigma=3, seed=123
+        )
+        with self.assertRaises(ToytreeError):
+            tree.mod.edges_make_ultrametric(
+                method="relaxed",
+                calibrations={-1: 1.0},
+                ncategories=[1, 2],
+                full=True,
+            )
+
+    def test_relaxed_reports_raw_and_penalized_scores(self):
+        """Relaxed fits should report score components explicitly."""
         tree = get_tree_with_uncorrelated_relaxed_rates(
             ntips=10, mean=3, sigma=3, seed=123
         )
         res = tree.mod.edges_make_ultrametric(
             method="relaxed",
             calibrations={-1: 1.0},
-            estimate=3,
+            lam=0.5,
             full=True,
             max_iter=500,
             max_fun=500,
             max_refine=2,
         )
-        self.assertEqual(res["estimated_parameter"], "lam")
-        self.assertGreaterEqual(float(res["estimated_value"]), 0.0)
-        self.assertLessEqual(float(res["estimated_value"]), 1.0)
+        self.assertGreaterEqual(float(res["loglik"]), float(res["penalized_loglik"]))
+        self.assertTrue(
+            np.isclose(
+                float(res["PHIIC"]),
+                -2 * float(res["loglik"])
+                + 2 * int(res["k"])
+                + 0.5 * float(res["penalty"]),
+            )
+        )
 
-    def test_estimate_invalid_for_clock(self):
+    def test_correlated_reports_raw_and_penalized_scores(self):
+        """Correlated fits should report score components explicitly."""
+        tree = get_tree_with_correlated_relaxed_rates(
+            ntips=10, mean=1.0, sigma=1.0, seed=123
+        )
+        res = tree.mod.edges_make_ultrametric(
+            method="correlated",
+            calibrations={-1: 1.0},
+            lam=0.5,
+            full=True,
+            max_iter=500,
+            max_fun=500,
+            max_refine=2,
+        )
+        self.assertGreaterEqual(float(res["loglik"]), float(res["penalized_loglik"]))
+        self.assertTrue(
+            np.isclose(
+                float(res["PHIIC"]),
+                -2 * float(res["loglik"])
+                + 2 * int(res["k"])
+                + 0.5 * float(res["penalty"]),
+            )
+        )
+
+    def test_clock_ignores_scalar_ncategories(self):
+        """Non-discrete modes should still ignore scalar ncategory values."""
         tree = get_tree_with_categorical_rates(ntips=10, nrates=1, seed=123)
+        res = tree.mod.edges_make_ultrametric(
+            method="clock",
+            calibrations={-1: 1.0},
+            ncategories=3,
+            full=True,
+        )
+        self.assertTrue(res["tree"].is_ultrametric())
+
+    def test_invalid_calibrations_raise_before_fit(self):
+        """Incompatible calibrated ages should fail before optimization."""
+        tree = get_tree_with_categorical_rates(ntips=10, nrates=1, seed=123)
+        mrca = tree.get_mrca_node(0, 1).idx
         with self.assertRaises(ToytreeError):
             tree.mod.edges_make_ultrametric(
                 method="clock",
-                calibrations={-1: 1.0},
-                estimate=3,
-                full=True,
+                calibrations={-1: 1.0, mrca: (1.1, 1.2)},
             )
+
+    def test_clock_recomputes_stats_from_repaired_ages(self):
+        """Clock summaries should match the repaired output tree ages."""
+        tree = toytree.tree("((a:1,b:1):1,c:1);")
+        valid_ages, _ = pl_clock._get_init_ages(tree, {tree.treenode.idx: (1.0, 1.0)})
+        invalid_ages = valid_ages.copy()
+        mrca = tree.get_mrca_node("a", "b").idx
+        invalid_ages[mrca] = invalid_ages[tree.treenode.idx] + 5e-9
+
+        with patch.object(pl_clock, "_decode_age_params", return_value=invalid_ages):
+            res = tree.mod.edges_make_ultrametric(
+                method="clock",
+                calibrations={-1: 1.0},
+                full=True,
+                max_iter=50,
+                max_fun=50,
+                max_refine=1,
+            )
+
+        returned_ages = res["tree"].get_node_data("height").values
+        edges = tree.get_edges("idx")
+        dists = tree.get_node_data("dist").values[:-1]
+        edata = np.vstack([dists, gammaln(dists + 1.0)]).T
+        expected = pl_clock.log_likelihood_poisson(
+            res["rate"],
+            returned_ages,
+            edges,
+            edata,
+            valid_loglik=None,
+        )
+
+        self.assertTrue(np.all(returned_ages[edges[:, 1]] > returned_ages[edges[:, 0]]))
+        self.assertTrue(np.isfinite(res["loglik"]))
+        self.assertTrue(np.isclose(res["loglik"], expected))

--- a/tests/mod/test_pl_multistart.py
+++ b/tests/mod/test_pl_multistart.py
@@ -24,7 +24,10 @@ from toytree.mod._src.penalized_likelihood.pl_utils import (
 
 
 class TestPenalizedLikelihoodMultistart(PytestCompat):
+    """Multistart regression tests for penalized-likelihood fits."""
+
     def test_clock_multistart_full_fields(self):
+        """Clock fits should expose multistart metadata."""
         tree = get_tree_with_categorical_rates(ntips=10, nrates=1, seed=123)
         res = edges_make_ultrametric_pl_clock(
             tree,
@@ -42,6 +45,7 @@ class TestPenalizedLikelihoodMultistart(PytestCompat):
         self.assertTrue(res["tree"].is_ultrametric())
 
     def test_discrete_multistart_seed_reproducible(self):
+        """Discrete multistart runs should be reproducible under a fixed seed."""
         tree = get_tree_with_categorical_rates(ntips=10, nrates=2, seed=123)
         kw = dict(
             ncategories=2,
@@ -60,6 +64,7 @@ class TestPenalizedLikelihoodMultistart(PytestCompat):
         self.assertTrue(np.isclose(r1["PHIIC"], r2["PHIIC"]))
 
     def test_discrete_ncat1_matches_clock(self):
+        """One discrete rate category should reduce exactly to the clock model."""
         tree = get_tree_with_categorical_rates(ntips=10, nrates=1, seed=123)
         kwargs = dict(
             calibrations={-1: 1.0},
@@ -81,6 +86,7 @@ class TestPenalizedLikelihoodMultistart(PytestCompat):
         )
 
     def test_relaxed_multistart_parallel(self):
+        """Relaxed fits should support multistart execution in parallel."""
         tree = get_tree_with_uncorrelated_relaxed_rates(
             ntips=10, mean=3, sigma=3, seed=123
         )
@@ -100,6 +106,7 @@ class TestPenalizedLikelihoodMultistart(PytestCompat):
         self.assertTrue(res["tree"].is_ultrametric())
 
     def test_correlated_multistart_parallel(self):
+        """Correlated fits should support multistart execution in parallel."""
         tree = get_tree_with_correlated_relaxed_rates(
             ntips=10, mean=1.0, sigma=1.0, seed=123
         )

--- a/tests/mod/test_pl_utils.py
+++ b/tests/mod/test_pl_utils.py
@@ -1,17 +1,24 @@
 import numpy as np
 from conftest import PytestCompat
 
+import toytree
 from toytree.mod._src.penalized_likelihood.pl_utils import (
     _decode_age_params,
     _encode_age_params,
+    _finalize_ultrametric_ages,
     _get_children_map_from_edges,
+    _normalize_calibrations,
     _pack_log_rates,
     _unpack_log_rates,
 )
+from toytree.utils import ToytreeError
 
 
 class TestPenalizedLikelihoodUtils(PytestCompat):
+    """Tests for shared penalized-likelihood helpers."""
+
     def test_pack_unpack_log_rates_roundtrip_with_floor(self):
+        """Pack/unpack should preserve positive rates with a floor."""
         rates = np.array([0.0, 1e-20, 0.5, 2.0], dtype=float)
         packed = _pack_log_rates(rates, rate_floor=1e-12)
         unpacked = _unpack_log_rates(packed)
@@ -19,12 +26,14 @@ class TestPenalizedLikelihoodUtils(PytestCompat):
         self.assertTrue(np.allclose(unpacked, expected))
 
     def test_get_children_map_from_edges(self):
+        """Children map should group edge endpoints by parent idx."""
         edges = np.array([[0, 3], [1, 3], [2, 4], [3, 4]], dtype=int)
         cmap = _get_children_map_from_edges(edges)
         self.assertTrue(np.array_equal(np.sort(cmap[3]), np.array([0, 1])))
         self.assertTrue(np.array_equal(np.sort(cmap[4]), np.array([2, 3])))
 
     def test_encode_decode_age_params_roundtrip(self):
+        """Age parameter transforms should round-trip valid ages."""
         edges = np.array([[0, 3], [1, 3], [2, 4], [3, 4]], dtype=int)
         cmap = _get_children_map_from_edges(edges)
         ages_idxs = np.array([3, 4], dtype=int)
@@ -38,6 +47,7 @@ class TestPenalizedLikelihoodUtils(PytestCompat):
         self.assertGreater(decoded[4], decoded[3])
 
     def test_decode_respects_child_order_and_upper_bounds(self):
+        """Decoded ages should stay ordered and inside finite bounds."""
         edges = np.array([[0, 3], [1, 3], [2, 4], [3, 4]], dtype=int)
         cmap = _get_children_map_from_edges(edges)
         ages_idxs = np.array([3, 4], dtype=int)
@@ -59,3 +69,42 @@ class TestPenalizedLikelihoodUtils(PytestCompat):
         # bounded transforms should respect calibration upper bounds
         self.assertLessEqual(decoded[3], 0.25)
         self.assertLessEqual(decoded[4], 0.3)
+
+    def test_finalize_ultrametric_ages_repairs_small_negative_branch(self):
+        """Tiny negative branches should be projected back to positive length."""
+        tree = toytree.tree("((a:1,b:1):1,c:1);")
+        mrca = tree.get_mrca_node("a", "b").idx
+        root = tree.treenode.idx
+        ages = np.zeros(tree.nnodes, dtype=float)
+        ages[mrca] = 0.5
+        ages[root] = ages[mrca] - 5e-9
+
+        repaired = _finalize_ultrametric_ages(tree, ages, dist_floor=1e-12)
+        edges = tree.get_edges("idx")
+        dists = repaired[edges[:, 1]] - repaired[edges[:, 0]]
+
+        self.assertGreater(repaired[root], repaired[mrca])
+        self.assertTrue(np.all(dists > 1e-12))
+
+    def test_finalize_ultrametric_ages_raises_on_large_negative_branch(self):
+        """Materially invalid branch lengths should raise instead of repair."""
+        tree = toytree.tree("((a:1,b:1):1,c:1);")
+        mrca = tree.get_mrca_node("a", "b").idx
+        root = tree.treenode.idx
+        ages = np.zeros(tree.nnodes, dtype=float)
+        ages[mrca] = 0.5
+        ages[root] = 0.49
+
+        with self.assertRaises(ToytreeError):
+            _finalize_ultrametric_ages(tree, ages, dist_floor=1e-12)
+
+    def test_normalize_calibrations_rejects_incompatible_bounds(self):
+        """Ancestor and descendant intervals should be checked for overlap."""
+        tree = toytree.tree("((a:1,b:1):1,c:1);")
+        mrca = tree.get_mrca_node("a", "b").idx
+        with self.assertRaises(ToytreeError):
+            _normalize_calibrations(
+                tree,
+                {-1: 0.8, mrca: (0.9, 0.95)},
+                dist_floor=1e-12,
+            )

--- a/toytree/cli/cli_make_ultrametric.py
+++ b/toytree/cli/cli_make_ultrametric.py
@@ -97,16 +97,20 @@ def run_make_ultrametric(args):
     if args.lam is not None and args.lam < 0:
         raise ToytreeError("--lam must be >= 0.")
     report_full = bool((args.full or args.json) and args.method != "extend")
-    force_full = bool(report_full or (args.estimate is not None))
-    if args.method == "discrete" and args.estimate is None and args.ncat is None:
-        raise ToytreeError(
-            "--ncat is required when --method discrete is used without --estimate."
-        )
+    has_ncat_search = bool(
+        args.method == "discrete" and args.ncat and len(args.ncat) > 1
+    )
+    force_full = bool(report_full or has_ncat_search)
+    if args.method == "discrete" and args.ncat is None:
+        raise ToytreeError("--ncat is required when --method discrete is used.")
+    ncategories = None
+    if args.ncat is not None:
+        ncategories = args.ncat[0] if len(args.ncat) == 1 else list(args.ncat)
 
     result = tre.mod.edges_make_ultrametric(
         method=args.method,
         calibrations=calibrations,
-        ncategories=None if args.ncat is None else int(args.ncat),
+        ncategories=ncategories,
         lam=args.lam,
         full=force_full,
         inplace=False,
@@ -116,18 +120,17 @@ def run_make_ultrametric(args):
         nstarts=args.nstarts,
         ncores=args.ncores,
         seed=args.seed,
-        estimate=args.estimate,
     )
     if force_full:
         if args.json:
             payload = {"method": args.method}
-            if args.estimate is not None:
+            if has_ncat_search:
                 payload["search"] = _jsonify_value(result.get("search", []))
-                payload["estimated_parameter"] = _jsonify_value(
-                    result.get("estimated_parameter")
+                payload["selected_ncategories"] = _jsonify_value(
+                    result.get("selected_ncategories")
                 )
-                payload["estimated_value"] = _jsonify_value(
-                    result.get("estimated_value")
+                payload["selection_criterion"] = _jsonify_value(
+                    result.get("selection_criterion")
                 )
             if report_full:
                 for key, val in result.items():
@@ -135,20 +138,20 @@ def run_make_ultrametric(args):
                         payload[str(key)] = _jsonify_value(val)
             print(json.dumps(payload, ensure_ascii=False, indent=2), file=sys.stderr)
         else:
-            if args.estimate is not None:
+            if has_ncat_search:
                 for rec in result.get("search", []):
                     cand = rec.get("candidate")
                     phiic = rec.get("PHIIC")
                     conv = rec.get("converged")
                     print(
-                        f"estimate candidate={cand} PHIIC={phiic} converged={conv}",
+                        f"ncat candidate={cand} PHIIC={phiic} converged={conv}",
                         file=sys.stderr,
                     )
                 print(
                     (
-                        "estimated_parameter="
-                        f"{result.get('estimated_parameter')} "
-                        f"estimated_value={result.get('estimated_value')}"
+                        "selected_ncategories="
+                        f"{result.get('selected_ncategories')} "
+                        f"selection_criterion={result.get('selection_criterion')}"
                     ),
                     file=sys.stderr,
                 )

--- a/toytree/cli/subparsers.py
+++ b/toytree/cli/subparsers.py
@@ -1540,7 +1540,7 @@ def get_parser_make_ultrametric(parser: ArgumentParser | None = None) -> Argumen
             $ make-ultrametric -i TREE.nwk -m relaxed --lam 0.5 -c -1=1.0 > UTREE.nwk
             $ make-ultrametric -i TREE.nwk -m correlated --lam 0.5 -c -1=1.0 > UTREE.nwk
             $ make-ultrametric -i TREE.nwk -m correlated --lam 0.5 --nstarts 8 --ncores 4 --seed 123 > UTREE.nwk
-            $ make-ultrametric -i TREE.nwk -m discrete --estimate 5 -c -1=1.0 > UTREE.nwk
+            $ make-ultrametric -i TREE.nwk -m discrete --ncat 1 2 4 -c -1=1.0 > UTREE.nwk
             $ make-ultrametric -i TREE.nwk -m correlated --lam 0.5 --json > UTREE.nwk 2> fit.json
             $ make-ultrametric -i TREE.nwk -m clock -c AB=0.8-1.2 CD=0.4
             $ cat TREE.nwk | make-ultrametric -i - --method extend
@@ -1613,9 +1613,10 @@ def get_parser_make_ultrametric(parser: ArgumentParser | None = None) -> Argumen
     method_group.add_argument(
         "--ncat",
         type=int,
+        nargs="+",
         default=None,
         metavar="int",
-        help="discrete only: number of rate categories (required unless --estimate is set)",
+        help="discrete only: one or more rate-category values; multiple values select by PHIIC",
     )
     method_group.add_argument(
         "--lam",
@@ -1624,14 +1625,6 @@ def get_parser_make_ultrametric(parser: ArgumentParser | None = None) -> Argumen
         metavar="float",
         help="relaxed/correlated only: penalty lambda; lower=weaker regularization [1.0]",
     )
-    method_group.add_argument(
-        "--estimate",
-        type=int,
-        default=None,
-        metavar="int",
-        help="estimate ncat/lam by PHIIC using this many candidate values",
-    )
-
     opt_group = p.add_argument_group(title="Optimization")
     opt_group.add_argument(
         "--max-iter",

--- a/toytree/mod/_src/penalized_likelihood/pl_clock.py
+++ b/toytree/mod/_src/penalized_likelihood/pl_clock.py
@@ -14,9 +14,11 @@ from toytree.mod._src.penalized_likelihood.pl_utils import (
     Calibrations,
     _decode_age_params,
     _encode_age_params,
+    _finalize_ultrametric_ages,
     _get_children_map_from_edges,
     _get_init_ages,
     _get_params_bounds,
+    _normalize_calibrations,
     _pack_log_rates,
     _run_multistart,
     _select_best_multistart,
@@ -183,6 +185,11 @@ def edges_make_ultrametric_pl_clock(
     """
     if calibrations is None:
         calibrations = {}
+    calibrations = _normalize_calibrations(
+        tree,
+        calibrations,
+        dist_floor=DIST_FLOOR,
+    )
 
     # get init and fixed node ages that make tree ultrametric
     ages_init, _ = _get_init_ages(tree, calibrations)
@@ -268,7 +275,8 @@ def edges_make_ultrametric_pl_clock(
     if not best["converged"]:
         logger.warning(f"Best multistart fit did not converge: {best['message']}")
     logger.debug(
-        f"clock multistart best objective={best['objective']}, start={best['start']}, nstarts={nstarts}"
+        "clock multistart best objective="
+        f"{best['objective']}, start={best['start']}, nstarts={nstarts}"
     )
 
     # transform tree with new ages
@@ -280,6 +288,12 @@ def edges_make_ultrametric_pl_clock(
         children_map,
         dist_floor=DIST_FLOOR,
         age_upper_switch=AGE_UPPER_SWITCH,
+    )
+    ages = _finalize_ultrametric_ages(
+        tree,
+        ages,
+        calibrations=calibrations,
+        dist_floor=DIST_FLOOR,
     )
     tree = tree.set_node_data("height", ages, inplace=inplace)
     rate = float(_unpack_log_rates(current_params[:1])[0])

--- a/toytree/mod/_src/penalized_likelihood/pl_correlated.py
+++ b/toytree/mod/_src/penalized_likelihood/pl_correlated.py
@@ -14,9 +14,11 @@ from toytree.mod._src.penalized_likelihood.pl_utils import (
     Calibrations,
     _decode_age_params,
     _encode_age_params,
+    _finalize_ultrametric_ages,
     _get_children_map_from_edges,
     _get_init_ages,
     _get_params_bounds,
+    _normalize_calibrations,
     _pack_log_rates,
     _run_multistart,
     _select_best_multistart,
@@ -30,6 +32,11 @@ RATE_FLOOR = 1e-12
 DIST_FLOOR = 1e-12
 INVALID_LOG_LIK_DROP = 1e6
 AGE_UPPER_SWITCH = 1e6
+
+
+def _invalid_objective(valid_loglik: float) -> float:
+    """Return the finite objective value used for invalid fits."""
+    return float(-(valid_loglik - INVALID_LOG_LIK_DROP))
 
 
 def _fit_correlated_start(payload: dict[str, Any]) -> dict[str, Any]:
@@ -51,6 +58,7 @@ def _fit_correlated_start(payload: dict[str, Any]) -> dict[str, Any]:
     max_fun = payload["max_fun"]
     max_refine = payload["max_refine"]
 
+    invalid_objective = _invalid_objective(valid_loglik)
     fit = minimize(
         fun=objective_correlated,
         x0=params,
@@ -108,7 +116,7 @@ def _fit_correlated_start(payload: dict[str, Any]) -> dict[str, Any]:
         if refit.fun < fit.fun:
             fit = refit
 
-    current_loglik = fit.fun
+    current_loglik = float(fit.fun)
     current_params = fit.x.copy()
     rsize = rates_init.size
     asize = ages_idxs.size
@@ -144,9 +152,9 @@ def _fit_correlated_start(payload: dict[str, Any]) -> dict[str, Any]:
             bounds=bounds[fslice],
             options=dict(maxiter=int(max_iter), maxfun=int(max_fun)),
         )
-        delta = ifit.fun - current_loglik
+        delta = float(ifit.fun) - current_loglik
         if delta <= 0:
-            current_loglik = ifit.fun
+            current_loglik = float(ifit.fun)
             current_params[fslice] = ifit.x
             fit = ifit
             if abs(delta) < 1e-9:
@@ -154,11 +162,16 @@ def _fit_correlated_start(payload: dict[str, Any]) -> dict[str, Any]:
         iter_refine += 1
         if iter_refine > max_refine:
             break
+    converged = bool(fit.success)
+    message = str(fit.message)
+    if current_loglik >= invalid_objective - 1e-9:
+        converged = False
+        message = "invalid objective plateau from infeasible start"
     return {
         "start": start,
         "objective": float(current_loglik),
-        "converged": bool(fit.success),
-        "message": str(fit.message),
+        "converged": converged,
+        "message": message,
         "nfev": int(getattr(fit, "nfev", -1)),
         "nit": int(getattr(fit, "nit", -1)),
         "params": current_params,
@@ -187,6 +200,11 @@ def edges_make_ultrametric_pl_correlated(
     """
     if calibrations is None:
         calibrations = {}
+    calibrations = _normalize_calibrations(
+        tree,
+        calibrations,
+        dist_floor=DIST_FLOOR,
+    )
 
     # get init and fixed node ages that make tree ultrametric
     ages_init, _ = _get_init_ages(tree, calibrations)
@@ -249,8 +267,6 @@ def edges_make_ultrametric_pl_correlated(
         sparams = params.copy()
         if start:
             sparams[:rsize] += rng.normal(0.0, 0.25, size=rsize)
-            if asize:
-                sparams[rsize : rsize + asize] += rng.normal(0.0, 0.25, size=asize)
         payloads.append(
             dict(
                 start=start,
@@ -278,7 +294,8 @@ def edges_make_ultrametric_pl_correlated(
     if not best["converged"]:
         logger.warning(f"Best multistart fit did not converge: {best['message']}")
     logger.debug(
-        f"correlated multistart best objective={best['objective']}, start={best['start']}, nstarts={nstarts}"
+        "correlated multistart best objective="
+        f"{best['objective']}, start={best['start']}, nstarts={nstarts}"
     )
 
     ages = _decode_age_params(
@@ -290,26 +307,33 @@ def edges_make_ultrametric_pl_correlated(
         dist_floor=DIST_FLOOR,
         age_upper_switch=AGE_UPPER_SWITCH,
     )
+    ages = _finalize_ultrametric_ages(
+        tree,
+        ages,
+        calibrations=calibrations,
+        dist_floor=DIST_FLOOR,
+    )
     tree = tree.set_node_data("height", ages, inplace=inplace)
     rates = _unpack_log_rates(current_params[:rsize])
 
-    loglik = log_likelihood_poisson_correlated(
+    penalized_loglik = log_likelihood_poisson_correlated(
         rates, ages, edges, edata, parent_edges, lam, valid_loglik
     )
+    loglik = log_likelihood_poisson_correlated(
+        rates, ages, edges, edata, parent_edges, 0.0, valid_loglik
+    )
+    penalty = _correlated_penalty(rates, parent_edges)
     k = len(bounds)
-    phiic = -2 * loglik + 2 * k
+    phiic = -2 * loglik + 2 * k + lam * penalty
 
     if not full:
         return tree
 
-    raw_loglik = log_likelihood_poisson_correlated(
-        rates, ages, edges, edata, parent_edges, 0.0, valid_loglik
-    )
-    penalty = _correlated_penalty(rates, parent_edges)
     return {
         "loglik": loglik,
-        "raw_loglik": raw_loglik,
+        "penalized_loglik": penalized_loglik,
         "penalty": penalty,
+        "k": k,
         "PHIIC": phiic,
         "rates": list(rates),
         "tree": tree,

--- a/toytree/mod/_src/penalized_likelihood/pl_discrete.py
+++ b/toytree/mod/_src/penalized_likelihood/pl_discrete.py
@@ -17,9 +17,11 @@ from toytree.mod._src.penalized_likelihood.pl_utils import (
     Calibrations,
     _decode_age_params,
     _encode_age_params,
+    _finalize_ultrametric_ages,
     _get_children_map_from_edges,
     _get_init_ages,
     _get_params_bounds,
+    _normalize_calibrations,
     _pack_log_rates,
     _run_multistart,
     _select_best_multistart,
@@ -139,7 +141,7 @@ def _fit_discrete_start(payload: dict[str, Any]) -> dict[str, Any]:
 def edges_make_ultrametric_pl_discrete(
     tree: ToyTree,
     ncategories: int,
-    calibrations: Calibrations = {},
+    calibrations: Calibrations | None = None,
     full: bool = False,
     inplace: bool = False,
     max_iter: int = 1e5,
@@ -149,8 +151,9 @@ def edges_make_ultrametric_pl_discrete(
     ncores: int = 1,
     seed: int | None = None,
 ) -> Union[ToyTree, dict[str, Any]]:
-    """Return a tree made ultrametric under a discrete model with N
-    rate categories under penalized likelihood.
+    """Return a tree made ultrametric under a discrete penalized-likelihood model.
+
+    This variant fits ``ncategories`` discrete rate categories.
 
     Edges are scaled while assuming a edge rates are drawn from N
     discrete distributions. The number of parameters in this model is
@@ -213,11 +216,18 @@ def edges_make_ultrametric_pl_discrete(
     >>>     else:
     >>>         node._dist = node._dist * rng.gamma(shape=3, scale=5.0)
     >>> tree.mod.edges_make_ultrametric_pl_discrete(tree, 2, full=True)
-    >>> # {'loglik': -82.42541, 'PHIIC': 216.85082, 'rates': [4.12272, 17.56474], 'freqs': [0.53751, 0.46248], 'tree': <toytree.ToyTree at 0x791451cb5190>, 'converged': True}
+    >>> # {'loglik': -82.42541, 'PHIIC': 216.85082, ...}
 
     """
     # ncategories cannot exceed number of edges
     ncategories = min(ncategories, tree.nedges)
+    if calibrations is None:
+        calibrations = {}
+    calibrations = _normalize_calibrations(
+        tree,
+        calibrations,
+        dist_floor=DIST_FLOOR,
+    )
 
     # strict identity with clock model when ncategories == 1.
     if int(ncategories) == 1:
@@ -341,7 +351,8 @@ def edges_make_ultrametric_pl_discrete(
     if not best["converged"]:
         logger.warning(f"Best multistart fit did not converge: {best['message']}")
     logger.debug(
-        f"discrete multistart best objective={best['objective']}, start={best['start']}, nstarts={nstarts}"
+        "discrete multistart best objective="
+        f"{best['objective']}, start={best['start']}, nstarts={nstarts}"
     )
 
     # transform tree with new ages
@@ -353,6 +364,12 @@ def edges_make_ultrametric_pl_discrete(
         children_map,
         dist_floor=DIST_FLOOR,
         age_upper_switch=AGE_UPPER_SWITCH,
+    )
+    ages = _finalize_ultrametric_ages(
+        tree,
+        ages,
+        calibrations=calibrations,
+        dist_floor=DIST_FLOOR,
     )
     tree = tree.set_node_data("height", ages, inplace=inplace)
 
@@ -479,7 +496,7 @@ def objective_discrete(
 def log_likelihood_poisson_discrete(
     rates_hat, ages_hat, edges, edata, freqs_hat, valid_loglik
 ) -> float:
-    """Return the log-likelihood of the rates x ages params"""
+    """Return the log-likelihood of the rates x ages params."""
     if valid_loglik is None:
         valid_loglik = -1.0
     invalid_score = valid_loglik - INVALID_LOG_LIK_DROP

--- a/toytree/mod/_src/penalized_likelihood/pl_make_ultrametric.py
+++ b/toytree/mod/_src/penalized_likelihood/pl_make_ultrametric.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Literal
 
 import numpy as np
@@ -108,65 +109,53 @@ def _run_one(
     )
 
 
-def _make_discrete_candidates(estimate: int, nedges: int) -> list[int]:
-    nedges = max(1, int(nedges))
-    raw = np.geomspace(1.0, float(nedges), num=int(estimate))
-    vals = sorted(set(np.clip(np.rint(raw).astype(int), 1, nedges).tolist()))
-    if 1 not in vals:
-        vals.insert(0, 1)
-    target = min(int(estimate), nedges)
-    if len(vals) < target:
-        existing = set(vals)
-        for cand in range(1, nedges + 1):
-            if cand not in existing:
-                vals.append(cand)
-                existing.add(cand)
-            if len(vals) >= target:
-                break
-        vals = sorted(vals)
-    return vals
-
-
-def _make_lam_candidates(estimate: int) -> list[float]:
-    return [float(i) for i in np.linspace(0.0, 1.0, int(estimate))]
-
-
-def _prepare_candidates(
-    tree: ToyTree,
-    method: str,
-    estimate: int,
-    estimate_values: list[int | float] | None,
-    ncategories: int | None,
-    lam: float | None,
-) -> tuple[str, list[int | float]]:
-    if method == "discrete":
-        if ncategories is not None:
-            return "ncategories", [int(ncategories)]
-        if estimate_values is not None:
-            vals = sorted({int(i) for i in estimate_values if int(i) >= 1})
-            return "ncategories", [min(v, tree.nedges) for v in vals]
-        return "ncategories", _make_discrete_candidates(estimate, tree.nedges)
-
-    if method in {"relaxed", "correlated"}:
-        if lam is not None:
-            # explicit lam acts as a fixed candidate under estimate mode.
-            return "lam", [float(lam)]
-        if estimate_values is not None:
-            vals = sorted({float(i) for i in estimate_values if float(i) >= 0.0})
-            return "lam", vals
-        return "lam", _make_lam_candidates(estimate)
-
-    raise ToytreeError(
-        "--estimate is only supported for method='discrete', 'relaxed', or 'correlated'."
-    )
-
-
 def _select_best_search(records: list[dict[str, Any]]) -> dict[str, Any]:
     finite = [i for i in records if np.isfinite(float(i.get("PHIIC", np.inf)))]
     if not finite:
-        raise ToytreeError("all estimate candidates failed to produce finite PHIIC.")
+        raise ToytreeError("all candidate fits failed to produce finite PHIIC.")
     finite = sorted(finite, key=lambda x: (float(x["PHIIC"]), float(x["candidate"])))
     return finite[0]
+
+
+def _coerce_discrete_candidates(
+    ncategories: int | Sequence[int] | None,
+    nedges: int,
+) -> int | list[int] | None:
+    """Return validated discrete-rate candidate count(s)."""
+    if ncategories is None:
+        return None
+    if isinstance(ncategories, np.integer):
+        return int(min(int(ncategories), int(nedges)))
+    if isinstance(ncategories, Sequence) and not isinstance(ncategories, (str, bytes)):
+        values: list[int] = []
+        seen: set[int] = set()
+        for value in ncategories:
+            if isinstance(value, bool):
+                raise ToytreeError("ncategories candidates must be positive integers.")
+            if isinstance(value, np.integer):
+                candidate = int(value)
+            else:
+                try:
+                    fval = float(value)
+                except (TypeError, ValueError) as exc:
+                    raise ToytreeError(
+                        "ncategories candidates must be positive integers."
+                    ) from exc
+                if not np.isfinite(fval) or not fval.is_integer():
+                    raise ToytreeError(
+                        "ncategories candidates must be positive integers."
+                    )
+                candidate = int(fval)
+            if candidate < 1:
+                raise ToytreeError("ncategories candidates must be >= 1.")
+            candidate = min(candidate, int(nedges))
+            if candidate not in seen:
+                values.append(candidate)
+                seen.add(candidate)
+        if not values:
+            raise ToytreeError("ncategories candidate list cannot be empty.")
+        return values
+    return int(min(int(ncategories), int(nedges)))
 
 
 @add_subpackage_method(TreeModAPI)
@@ -174,7 +163,7 @@ def edges_make_ultrametric(
     tree: ToyTree,
     method: Literal["extend", "clock", "discrete", "relaxed", "correlated"],
     calibrations: dict[int, Any] | None = None,
-    ncategories: int | None = None,
+    ncategories: int | Sequence[int] | None = None,
     lam: float | None = None,
     full: bool = False,
     inplace: bool = False,
@@ -184,8 +173,6 @@ def edges_make_ultrametric(
     nstarts: int = 1,
     ncores: int = 1,
     seed: int | None = None,
-    estimate: int | None = None,
-    estimate_values: list[int | float] | None = None,
 ):
     """Make a tree ultrametric using a selected transformation/model workflow.
 
@@ -194,11 +181,8 @@ def edges_make_ultrametric(
     ``"extend"``, ``"clock"``, ``"discrete"``, ``"relaxed"``, or
     ``"correlated"``.
 
-    For penalized-likelihood methods, this function can also estimate a
-    tuning parameter by searching candidate values and selecting the best
-    fit by minimum PHIIC:
-    - ``ncategories`` for ``method="discrete"``
-    - ``lam`` for ``method in {"relaxed", "correlated"}``
+    For ``method="discrete"``, users can pass multiple ``ncategories``
+    candidates and select the best fit by minimum PHIIC.
 
     Parameters
     ----------
@@ -213,10 +197,10 @@ def edges_make_ultrametric(
         fixed age (single numeric value) or an allowed age interval
         ``(min_age, max_age)``. Used by penalized-likelihood methods and
         ignored by ``method="extend"``.
-    ncategories: int or None
-        Number of rate categories for ``method="discrete"``. Required for
-        discrete fitting when ``estimate`` is not used (unless provided via
-        ``estimate_values``).
+    ncategories: int, sequence of int, or None
+        Number of rate categories for ``method="discrete"``. A single
+        integer fits one discrete model. A sequence of integers fits each
+        candidate and selects the best by minimum PHIIC.
     lam: float or None
         Non-negative smoothing/penalty parameter for
         ``method in {"relaxed", "correlated"}``.
@@ -240,13 +224,6 @@ def edges_make_ultrametric(
         ``nstarts > 1``).
     seed: int or None
         Random seed for reproducible multistart initialization.
-    estimate: int or None
-        If provided, enable parameter search mode over ``estimate``
-        candidates and select the best by PHIIC. Supported only for
-        ``method="discrete"``, ``"relaxed"``, and ``"correlated"``.
-    estimate_values: list[int | float] or None
-        Optional explicit candidate values for search mode. If provided,
-        these override automatically generated candidates.
 
     Returns
     -------
@@ -254,26 +231,23 @@ def edges_make_ultrametric(
         Returned when ``full=False``. The transformed ultrametric tree.
     dict[str, Any]
         Returned when ``full=True``. Includes backend model-fit outputs.
-        In search mode (``estimate is not None``), also includes:
-        ``estimated_parameter``, ``estimated_value``, and ``search``.
+        When ``method="discrete"`` is called with multiple ``ncategories``
+        candidates, also includes ``selected_ncategories``,
+        ``selection_criterion``, and ``search``.
 
     Raises
     ------
     ToytreeError
-        Raised for invalid method names, invalid/unsupported estimate mode,
-        negative ``lam``, missing required discrete settings, invalid
-        candidate sets, or if all search candidates fail to return finite
-        PHIIC.
+        Raised for invalid method names, negative ``lam``, missing
+        required discrete settings, invalid candidate sets, or if all
+        discrete candidate fits fail to return finite PHIIC.
 
     Notes
     -----
-    In search mode, candidate selection is deterministic:
+    When multiple discrete candidates are supplied, candidate selection is
+    deterministic:
     - Lowest PHIIC wins.
     - Ties are broken by selecting the smaller candidate value.
-
-    Default search candidates:
-    - ``discrete``: approximately geometric spacing over ``[1, tree.nedges]``
-    - ``relaxed/correlated``: linear spacing over ``[0.0, 1.0]``
 
     Examples
     --------
@@ -290,19 +264,18 @@ def edges_make_ultrametric(
     >>> t3 = tree.mod.edges_make_ultrametric(
     ...     method="discrete", calibrations=cal, ncategories=3)
 
-    Fit a relaxed rate model and estimate lambda parameter
-    >>> t4 = tree.mod.edges_make_ultrametric(
-    ...     method="relaxed", estimate=5, nstarts=5, ncores=5,
-    ... )
-
-    Fit a correlated rates model, estimate, and get full result dict
+    Compare several discrete models and select the best by PHIIC
     >>> res = tree.mod.edges_make_ultrametric(
-    ...     method="correlated",
-    ...     estimate=4,
-    ...     estimate_values=[0.0, 0.25, 0.5, 1.0],
+    ...     method="discrete",
+    ...     calibrations=cal,
+    ...     ncategories=[1, 2, 4],
     ...     full=True,
     ... )
     >>> print(res)
+
+    Fit a correlated rates model with a fixed lambda and inspect PHIIC
+    >>> t4 = tree.mod.edges_make_ultrametric(
+    ...     method="correlated", lam=0.5, calibrations=cal, full=True)
 
     See Also
     --------
@@ -316,13 +289,26 @@ def edges_make_ultrametric(
     calibrations = {} if calibrations is None else calibrations
     if lam is not None and lam < 0:
         raise ToytreeError("lam must be >= 0.")
+    if (
+        method != "discrete"
+        and isinstance(ncategories, Sequence)
+        and not isinstance(ncategories, (str, bytes))
+    ):
+        raise ToytreeError(
+            "ncategories candidate lists are only supported for method='discrete'."
+        )
+    ncat_values = (
+        _coerce_discrete_candidates(ncategories, tree.nedges)
+        if method == "discrete"
+        else ncategories
+    )
 
-    if estimate is None:
+    if not isinstance(ncat_values, list):
         return _run_one(
             tree=tree,
             method=method,
             calibrations=calibrations,
-            ncategories=ncategories,
+            ncategories=ncat_values,
             lam=lam,
             full=full,
             inplace=inplace,
@@ -334,29 +320,15 @@ def edges_make_ultrametric(
             seed=seed,
         )
 
-    estimate = int(estimate)
-    if estimate < 1:
-        raise ToytreeError("estimate must be >= 1.")
-    param_name, candidates = _prepare_candidates(
-        tree=tree,
-        method=method,
-        estimate=estimate,
-        estimate_values=estimate_values,
-        ncategories=ncategories,
-        lam=lam if method in {"relaxed", "correlated"} else None,
-    )
-    if not candidates:
-        raise ToytreeError("no valid candidates generated for --estimate.")
-
     search: list[dict[str, Any]] = []
     best_result: dict[str, Any] | None = None
-    for cand in candidates:
+    for cand in ncat_values:
         kwargs = dict(
             tree=tree,
             method=method,
             calibrations=calibrations,
-            ncategories=int(cand) if param_name == "ncategories" else ncategories,
-            lam=float(cand) if param_name == "lam" else lam,
+            ncategories=int(cand),
+            lam=lam,
             full=True,
             inplace=False,
             max_iter=max_iter,
@@ -366,7 +338,7 @@ def edges_make_ultrametric(
             ncores=ncores,
             seed=seed,
         )
-        candidate_value = int(cand) if param_name == "ncategories" else float(cand)
+        candidate_value = int(cand)
         try:
             result = _run_one(**kwargs)
             record = {
@@ -412,8 +384,8 @@ def edges_make_ultrametric(
             tree=tree,
             method=method,
             calibrations=calibrations,
-            ncategories=int(selected) if param_name == "ncategories" else ncategories,
-            lam=float(selected) if param_name == "lam" else lam,
+            ncategories=int(selected),
+            lam=lam,
             full=True,
             inplace=True,
             max_iter=max_iter,
@@ -429,7 +401,7 @@ def edges_make_ultrametric(
     if not full:
         return final["tree"]
 
-    final["estimated_parameter"] = param_name
-    final["estimated_value"] = selected
+    final["selected_ncategories"] = int(selected)
+    final["selection_criterion"] = "PHIIC"
     final["search"] = search
     return final

--- a/toytree/mod/_src/penalized_likelihood/pl_relaxed.py
+++ b/toytree/mod/_src/penalized_likelihood/pl_relaxed.py
@@ -14,9 +14,11 @@ from toytree.mod._src.penalized_likelihood.pl_utils import (
     Calibrations,
     _decode_age_params,
     _encode_age_params,
+    _finalize_ultrametric_ages,
     _get_children_map_from_edges,
     _get_init_ages,
     _get_params_bounds,
+    _normalize_calibrations,
     _pack_log_rates,
     _run_multistart,
     _select_best_multistart,
@@ -30,6 +32,11 @@ RATE_FLOOR = 1e-12
 DIST_FLOOR = 1e-12
 INVALID_LOG_LIK_DROP = 1e6
 AGE_UPPER_SWITCH = 1e6
+
+
+def _invalid_objective(valid_loglik: float) -> float:
+    """Return the finite objective value used for invalid fits."""
+    return float(-(valid_loglik - INVALID_LOG_LIK_DROP))
 
 
 def _fit_relaxed_start(payload: dict[str, Any]) -> dict[str, Any]:
@@ -50,6 +57,7 @@ def _fit_relaxed_start(payload: dict[str, Any]) -> dict[str, Any]:
     max_fun = payload["max_fun"]
     max_refine = payload["max_refine"]
 
+    invalid_objective = _invalid_objective(valid_loglik)
     fit = minimize(
         fun=objective_relaxed,
         x0=params,
@@ -105,7 +113,7 @@ def _fit_relaxed_start(payload: dict[str, Any]) -> dict[str, Any]:
         if refit.fun < fit.fun:
             fit = refit
 
-    current_loglik = fit.fun
+    current_loglik = float(fit.fun)
     current_params = fit.x.copy()
     rsize = rates_init.size
     asize = ages_idxs.size
@@ -140,9 +148,9 @@ def _fit_relaxed_start(payload: dict[str, Any]) -> dict[str, Any]:
             bounds=bounds[fslice],
             options=dict(maxiter=int(max_iter), maxfun=int(max_fun)),
         )
-        delta = ifit.fun - current_loglik
+        delta = float(ifit.fun) - current_loglik
         if delta <= 0:
-            current_loglik = ifit.fun
+            current_loglik = float(ifit.fun)
             current_params[fslice] = ifit.x
             fit = ifit
             if abs(delta) < 1e-9:
@@ -150,11 +158,16 @@ def _fit_relaxed_start(payload: dict[str, Any]) -> dict[str, Any]:
         iter_refine += 1
         if iter_refine > max_refine:
             break
+    converged = bool(fit.success)
+    message = str(fit.message)
+    if current_loglik >= invalid_objective - 1e-9:
+        converged = False
+        message = "invalid objective plateau from infeasible start"
     return {
         "start": start,
         "objective": float(current_loglik),
-        "converged": bool(fit.success),
-        "message": str(fit.message),
+        "converged": converged,
+        "message": message,
         "nfev": int(getattr(fit, "nfev", -1)),
         "nit": int(getattr(fit, "nit", -1)),
         "params": current_params,
@@ -164,7 +177,7 @@ def _fit_relaxed_start(payload: dict[str, Any]) -> dict[str, Any]:
 def edges_make_ultrametric_pl_relaxed(
     tree: ToyTree,
     lam: float,
-    calibrations: Calibrations = {},
+    calibrations: Calibrations | None = None,
     full: bool = False,
     inplace: bool = False,
     max_iter: int = 1e5,
@@ -174,8 +187,7 @@ def edges_make_ultrametric_pl_relaxed(
     ncores: int = 1,
     seed: int | None = None,
 ) -> Union[ToyTree, dict[str, Any]]:
-    """Return a tree made ultrametric under a relaxed clock model with
-    rate variation among edges under penalized likelihood.
+    """Return a tree made ultrametric under a relaxed-clock PL model.
 
     Edges are scaled while allowing each edge to have its own rate,
     and a penalty is applied to discourage excessive variation away
@@ -224,6 +236,14 @@ def edges_make_ultrametric_pl_relaxed(
         as well as statistics on the model fit including likelihood,
         PHIIC, and rates.
     """
+    if calibrations is None:
+        calibrations = {}
+    calibrations = _normalize_calibrations(
+        tree,
+        calibrations,
+        dist_floor=DIST_FLOOR,
+    )
+
     # get init and fixed node ages that make tree ultrametric
     ages_init, _ = _get_init_ages(tree, calibrations)
 
@@ -279,8 +299,6 @@ def edges_make_ultrametric_pl_relaxed(
         sparams = params.copy()
         if start:
             sparams[:rsize] += rng.normal(0.0, 0.25, size=rsize)
-            if asize:
-                sparams[rsize : rsize + asize] += rng.normal(0.0, 0.25, size=asize)
         payloads.append(
             dict(
                 start=start,
@@ -307,7 +325,8 @@ def edges_make_ultrametric_pl_relaxed(
     if not best["converged"]:
         logger.warning(f"Best multistart fit did not converge: {best['message']}")
     logger.debug(
-        f"relaxed multistart best objective={best['objective']}, start={best['start']}, nstarts={nstarts}"
+        "relaxed multistart best objective="
+        f"{best['objective']}, start={best['start']}, nstarts={nstarts}"
     )
 
     # transform tree with new ages
@@ -320,29 +339,35 @@ def edges_make_ultrametric_pl_relaxed(
         dist_floor=DIST_FLOOR,
         age_upper_switch=AGE_UPPER_SWITCH,
     )
+    ages = _finalize_ultrametric_ages(
+        tree,
+        ages,
+        calibrations=calibrations,
+        dist_floor=DIST_FLOOR,
+    )
     tree = tree.set_node_data("height", ages, inplace=inplace)
 
     # get rates params
     rates = _unpack_log_rates(current_params[:rsize])
 
-    # Final fit for PHIIC calculation (Penalized Hierarchical Information Criterion)
-    loglik = log_likelihood_poisson_relaxed(
+    penalized_loglik = log_likelihood_poisson_relaxed(
         rates, ages, edges, edata, lam, valid_loglik
     )
+    loglik = log_likelihood_poisson_relaxed(
+        rates, ages, edges, edata, 0.0, valid_loglik
+    )
+    penalty = _relaxed_penalty(rates)
     k = len(bounds)
-    PHIIC = -2 * loglik + 2 * k
+    PHIIC = -2 * loglik + 2 * k + lam * penalty
 
     # return as a tree or a dict
     if not full:
         return tree
-    raw_loglik = log_likelihood_poisson_relaxed(
-        rates, ages, edges, edata, 0.0, valid_loglik
-    )
-    penalty = _relaxed_penalty(rates)
     return {
         "loglik": loglik,
-        "raw_loglik": raw_loglik,
+        "penalized_loglik": penalized_loglik,
         "penalty": penalty,
+        "k": k,
         "PHIIC": PHIIC,
         "rates": list(rates),
         "tree": tree,

--- a/toytree/mod/_src/penalized_likelihood/pl_utils.py
+++ b/toytree/mod/_src/penalized_likelihood/pl_utils.py
@@ -9,10 +9,12 @@ import numpy as np
 from loguru import logger
 
 from toytree.core import ToyTree
+from toytree.utils import ToytreeError
 
 Calibrations = Dict[int, Tuple[float, float]]
 PARAM_MIN = 1e-8
 PARAM_MAX = 1e8
+FINAL_AGE_NEGATIVE_TOL = 1e-8
 
 
 def _pack_log_rates(rates: np.ndarray, rate_floor: float = 1e-12) -> np.ndarray:
@@ -120,6 +122,133 @@ def _age_has_upper(
     lo: float, hi: float, dist_floor: float, age_upper_switch: float
 ) -> bool:
     return np.isfinite(hi) and (hi < age_upper_switch) and (hi > lo + dist_floor)
+
+
+def _coerce_calibration_interval(calib: Any) -> tuple[float, float]:
+    """Return one calibration coerced to a finite closed interval."""
+    if isinstance(calib, (float, int)):
+        lo = hi = float(calib)
+    else:
+        try:
+            lo, hi = calib
+        except Exception as exc:  # pragma: no cover
+            raise ToytreeError(
+                "calibrations must be numeric ages or (min_age, max_age) pairs."
+            ) from exc
+        lo = float(lo)
+        hi = float(hi)
+    if not (np.isfinite(lo) and np.isfinite(hi)):
+        raise ToytreeError("calibrations must contain only finite numeric ages.")
+    if lo > hi:
+        raise ToytreeError(
+            f"invalid calibration interval ({lo}, {hi}): min_age cannot exceed max_age."
+        )
+    return lo, hi
+
+
+def _normalize_calibrations(
+    tree: ToyTree,
+    calibrations: dict[Any, Any] | None,
+    dist_floor: float = 1e-12,
+) -> dict[int, tuple[float, float]]:
+    """Return calibrations normalized to node idx keys after validation."""
+    if not calibrations:
+        return {}
+
+    normalized: dict[int, tuple[float, float]] = {}
+    for selector, calib in calibrations.items():
+        node = tree.get_nodes(selector)[0]
+        normalized[node.idx] = _coerce_calibration_interval(calib)
+
+    for desc_idx, (desc_min, _) in normalized.items():
+        for anc in tree[desc_idx].iter_ancestors():
+            anc_bounds = normalized.get(anc.idx)
+            if anc_bounds is None:
+                continue
+            if desc_min + dist_floor > anc_bounds[1]:
+                raise ToytreeError(
+                    "incompatible calibrations: descendant node "
+                    f"{desc_idx} minimum age {desc_min} exceeds ancestor node "
+                    f"{anc.idx} maximum age {anc_bounds[1]} after enforcing "
+                    "positive branch lengths."
+                )
+    return normalized
+
+
+def _raise_invalid_final_ages(
+    edges: np.ndarray,
+    dists: np.ndarray,
+    reason: str,
+) -> None:
+    """Raise a consistent error for invalid finalized ages."""
+    bad = np.where(~np.isfinite(dists) | (dists <= 0))[0]
+    if bad.size:
+        eidx = int(bad[0])
+    else:
+        eidx = int(np.argmin(dists))
+    child, parent = [int(i) for i in edges[eidx]]
+    dist = float(dists[eidx])
+    raise ToytreeError(
+        "ultrametric fit produced invalid final node ages: "
+        f"branch {child}->{parent} has length {dist:.6g}. {reason}"
+    )
+
+
+def _finalize_ultrametric_ages(
+    tree: ToyTree,
+    ages: np.ndarray,
+    calibrations: dict[int, tuple[float, float]] | None = None,
+    dist_floor: float = 1e-12,
+    negative_tol: float = FINAL_AGE_NEGATIVE_TOL,
+) -> np.ndarray:
+    """Return finalized ages with tiny topology jitter repaired."""
+    ages_hat = np.asarray(ages, dtype=float).copy()
+    if np.any(~np.isfinite(ages_hat)):
+        raise ToytreeError("ultrametric fit produced non-finite node ages.")
+
+    edges = tree.get_edges("idx")
+    children = edges[:, 0]
+    parents = edges[:, 1]
+    dists = ages_hat[parents] - ages_hat[children]
+    min_dist = float(dists.min()) if dists.size else np.inf
+    if min_dist < -negative_tol:
+        _raise_invalid_final_ages(
+            edges,
+            dists,
+            "This usually indicates incompatible calibrations or optimizer failure.",
+        )
+
+    if np.any(dists <= dist_floor):
+        # Project small post-fit violations back onto a strictly positive tree.
+        for node in tree[tree.ntips :]:
+            child_idxs = np.fromiter((i.idx for i in node.children), dtype=int)
+            if not child_idxs.size:
+                continue
+            min_age = np.nextafter(
+                float(ages_hat[child_idxs].max()) + dist_floor,
+                np.inf,
+            )
+            if ages_hat[node.idx] < min_age:
+                ages_hat[node.idx] = min_age
+
+    if calibrations:
+        for nidx, (lo, hi) in calibrations.items():
+            age = float(ages_hat[nidx])
+            if age < lo - negative_tol or age > hi + negative_tol:
+                raise ToytreeError(
+                    "ultrametric fit repair would violate calibration bounds at "
+                    f"node {nidx}: repaired age {age:.6g} is outside "
+                    f"[{lo:.6g}, {hi:.6g}]."
+                )
+
+    dists = ages_hat[parents] - ages_hat[children]
+    if np.any(~np.isfinite(dists)) or np.any(dists <= dist_floor):
+        _raise_invalid_final_ages(
+            edges,
+            dists,
+            "Final age repair could not recover a strictly positive ultrametric tree.",
+        )
+    return ages_hat
 
 
 def _encode_age_params(
@@ -241,7 +370,8 @@ def _get_init_ages(
                 # divide span into nnodes on path intervals
                 span = max_age - min_age
                 ages[nidx] = max_age - span / nsplits
-                # logger.debug(f"{path}, nidx={nidx}, cidx={cidx}, pidx={pidx}, nsplits={nsplits}, min_age={min_age:.2f}, max_age={max_age:.2f} | set {nidx} to {ages[nidx]:.2f}")
+                # Historical debug output kept here as a guide for how
+                # starting ages are interpolated along calibrated paths.
 
     # get age edge lengths
     children = edges[:, 0]
@@ -302,8 +432,7 @@ def _get_params_bounds(
 
 
 def get_tree_with_categorical_rates(ntips: int, nrates: int, seed: int) -> ToyTree:
-    """Return a ToyTree with edge dists scaled to reflect randomly
-    assigned categorical rate variation.
+    """Return a ToyTree with edges scaled by categorical rate variation.
 
     Rate categories are evenly assigned (linspace) between 1 and 10
     and each edge is randomly assigned to a category. The rate scaler
@@ -328,8 +457,7 @@ def get_tree_with_categorical_rates(ntips: int, nrates: int, seed: int) -> ToyTr
 def get_tree_with_uncorrelated_relaxed_rates(
     ntips: int, mean: float = 1.0, sigma: float = 1.0, seed: int = None
 ) -> ToyTree:
-    """Return a ToyTree with edge dists scaled to reflect uncorrelated
-    relaxed clock rates.
+    """Return a ToyTree with edges scaled by uncorrelated relaxed-clock rates.
 
     A gamma distribution is parameterized with a shape and scale to
     match the desired mean and sigma values, and each branch dist
@@ -357,8 +485,7 @@ def get_tree_with_uncorrelated_relaxed_rates(
 def get_tree_with_correlated_relaxed_rates(
     ntips: int, mean: float = 0.0, sigma: float = 1.0, seed: int = None
 ) -> ToyTree:
-    """Return a ToyTree with edge dists scaled to reflect uncorrelated
-    relaxed clock rates.
+    """Return a ToyTree with edges scaled by correlated relaxed-clock rates.
 
     A gamma distribution is parameterized with a shape and scale to
     match the desired mean and sigma values, and each branch dist


### PR DESCRIPTION
## Summary
- remove `estimate` / `estimate_values` from `edges_make_ultrametric`
- support PHIIC-based discrete model selection via multi-value `ncategories`
- clarify penalized-likelihood result reporting and multistart diagnostics

## Validation
- `pytest -q tests/mod`
- `pytest -q tests/cli/test_make_ultrametric_cli.py`
