### PR TITLE
[codex] add imap support to relabel

### DIFF
--- a/tests/cli/test_relabel_cli.py
+++ b/tests/cli/test_relabel_cli.py
@@ -2,7 +2,7 @@
 
 import io
 import tempfile
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from conftest import PytestCompat
@@ -20,22 +20,23 @@ class TestRelabelCLI(PytestCompat):
         self.tree_path.write_text("((aa|x:1,ab|y:1):1,c|z:1);\n", encoding="utf-8")
         self.parser = get_parser_relabel()
 
-    def _run_capture_stdout(self, argv):
+    def _run_capture(self, argv):
         args = self.parser.parse_args(argv)
-        stream = io.StringIO()
-        with redirect_stdout(stream):
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
             run_relabel(args)
-        return stream.getvalue().strip()
+        return out.getvalue().strip(), err.getvalue()
 
     def test_strip(self):
-        out_nwk = self._run_capture_stdout(["-i", str(self.tree_path), "--strip", "az"])
+        out_nwk, _ = self._run_capture(["-i", str(self.tree_path), "--strip", "az"])
         tree = toytree.tree(out_nwk)
         self.assertEqual(tree[0].name, "|x")
         self.assertEqual(tree[1].name, "b|y")
         self.assertEqual(tree[2].name, "c|")
 
     def test_delim_and_idxs(self):
-        out_nwk = self._run_capture_stdout(
+        out_nwk, _ = self._run_capture(
             ["-i", str(self.tree_path), "--delim", "|", "--delim-idxs", "0"]
         )
         tree = toytree.tree(out_nwk)
@@ -44,7 +45,7 @@ class TestRelabelCLI(PytestCompat):
         self.assertEqual(tree[2].name, "c")
 
     def test_nodes_subset(self):
-        out_nwk = self._run_capture_stdout(
+        out_nwk, _ = self._run_capture(
             ["-i", str(self.tree_path), "-n", "~^aa", "--append", "_X"]
         )
         tree = toytree.tree(out_nwk)
@@ -53,7 +54,7 @@ class TestRelabelCLI(PytestCompat):
         self.assertEqual(tree[2].name, "c|z")
 
     def test_italic_and_bold(self):
-        out_nwk = self._run_capture_stdout(
+        out_nwk, _ = self._run_capture(
             ["-i", str(self.tree_path), "--prepend", "X_", "--italic", "--bold"]
         )
         tree = toytree.tree(out_nwk)
@@ -70,17 +71,70 @@ class TestRelabelCLI(PytestCompat):
         self.assertEqual(obj[0].name, "X_aa|x")
 
     def test_tips_only_false(self):
-        out_nwk = self._run_capture_stdout(
+        out_nwk, _ = self._run_capture(
             ["-i", str(self.tree_path), "--prepend", "X_", "--tips-only", "false"]
         )
         tree = toytree.tree(out_nwk)
         self.assertEqual(tree[3].name, "")  # unchanged internal empty name
 
     def test_stripleft(self):
-        out_nwk = self._run_capture_stdout(
+        out_nwk, _ = self._run_capture(
             ["-i", str(self.tree_path), "--stripleft", "ac"]
         )
         tree = toytree.tree(out_nwk)
         self.assertEqual(tree[0].name, "|x")
         self.assertEqual(tree[1].name, "b|y")
         self.assertEqual(tree[2].name, "|z")
+
+    def test_imap_file_renames_tips_and_ignores_extra_columns(self):
+        imap = self.tmpdir / "imap.txt"
+        imap.write_text(
+            "aa|x alpha extra\nab|y beta ignored\n",
+            encoding="utf-8",
+        )
+        out_nwk, err = self._run_capture(
+            ["-i", str(self.tree_path), "--imap", str(imap)]
+        )
+        tree = toytree.tree(out_nwk)
+        self.assertEqual(err, "")
+        self.assertEqual(tree[0].name, "alpha")
+        self.assertEqual(tree[1].name, "beta")
+        self.assertEqual(tree[2].name, "c|z")
+
+    def test_imap_warns_on_unmatched_and_still_writes_tree(self):
+        imap = self.tmpdir / "imap_warn.txt"
+        imap.write_text(
+            "missing nope\nc|z charlie\n",
+            encoding="utf-8",
+        )
+        out_nwk, err = self._run_capture(
+            ["-i", str(self.tree_path), "--imap", str(imap)]
+        )
+        tree = toytree.tree(out_nwk)
+        self.assertIn(
+            "WARNING: imap selector 'missing' did not match any tip names.",
+            err,
+        )
+        self.assertEqual(tree[2].name, "charlie")
+
+    def test_imap_overrides_prior_transforms(self):
+        imap = self.tmpdir / "imap_override.txt"
+        imap.write_text("aa|x alpha\n", encoding="utf-8")
+        out_nwk, _ = self._run_capture(
+            [
+                "-i",
+                str(self.tree_path),
+                "--delim",
+                "|",
+                "--delim-idxs",
+                "0",
+                "--prepend",
+                "X_",
+                "--imap",
+                str(imap),
+            ]
+        )
+        tree = toytree.tree(out_nwk)
+        self.assertEqual(tree[0].name, "alpha")
+        self.assertEqual(tree[1].name, "X_ab")
+        self.assertEqual(tree[2].name, "X_c")

--- a/tests/core/test_relabel.py
+++ b/tests/core/test_relabel.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+import io
+import tempfile
+from contextlib import redirect_stderr
+from pathlib import Path
 
 from conftest import PytestCompat
 
@@ -11,6 +15,7 @@ class TestRelabel(PytestCompat):
         self.tree = toytree.tree("((a-1:1,b-2:1):1,c-3:1);")
         # assign internal names for tests that include non-tip nodes
         self.tree = self.tree.set_node_data("name", {3: "I-1", 4: "R-1"}, inplace=False)
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="toytree-core-relabel-"))
 
     def test_default_tips_only(self):
         new = self.tree.relabel(fn=str.upper, inplace=False)
@@ -79,3 +84,59 @@ class TestRelabel(PytestCompat):
         tre = self.tree.set_node_data("name", {0: "<b><i>a-1</i></b>"}, inplace=False)
         new = tre.relabel(queries=[0], italic=True, bold=True, inplace=False)
         self.assertEqual(new[0].name, "<b><i>a-1</i></b>")
+
+    def test_imap_dict_exact_tip_names(self):
+        new = self.tree.relabel(imap={"a-1": "alpha", "c-3": "charlie"}, inplace=False)
+        self.assertEqual(new[0].name, "alpha")
+        self.assertEqual(new[1].name, "b-2")
+        self.assertEqual(new[2].name, "charlie")
+
+    def test_imap_dict_regex_selector(self):
+        tre = toytree.tree("((aa:1,ab:1):1,c:1);")
+        new = tre.relabel(imap={"~^ab$": "beta"}, inplace=False)
+        self.assertEqual(new[0].name, "aa")
+        self.assertEqual(new[1].name, "beta")
+        self.assertEqual(new[2].name, "c")
+
+    def test_imap_file_ignores_extra_columns(self):
+        imap = self.tmpdir / "imap.txt"
+        imap.write_text("a-1 alpha extra\nc-3 charlie ignored\n", encoding="utf-8")
+        new = self.tree.relabel(imap=imap, inplace=False)
+        self.assertEqual(new[0].name, "alpha")
+        self.assertEqual(new[2].name, "charlie")
+
+    def test_imap_warns_on_unmatched_and_continues(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            new = self.tree.relabel(
+                imap={"missing": "X", "a-1": "alpha"},
+                inplace=False,
+            )
+        self.assertEqual(new[0].name, "alpha")
+        self.assertEqual(new[1].name, "b-2")
+        self.assertIn(
+            "WARNING: imap selector 'missing' did not match any tip names.",
+            buf.getvalue(),
+        )
+
+    def test_imap_raises_on_ambiguous_selector(self):
+        tre = toytree.tree("((aa:1,ab:1):1,c:1);")
+        with self.assertRaisesRegex(Exception, "matched multiple tips"):
+            tre.relabel(imap={"~^a": "ambig"}, inplace=False)
+
+    def test_imap_raises_when_two_selectors_hit_same_tip(self):
+        tre = toytree.tree("((aa:1,ab:1):1,c:1);")
+        with self.assertRaisesRegex(Exception, "both matched tip 'aa'"):
+            tre.relabel(imap={"aa": "alpha", "~^aa$": "beta"}, inplace=False)
+
+    def test_imap_applies_after_other_transforms(self):
+        new = self.tree.relabel(
+            delim="-",
+            delim_idxs=0,
+            fn=str.upper,
+            imap={"a-1": "alpha"},
+            inplace=False,
+        )
+        self.assertEqual(new[0].name, "alpha")
+        self.assertEqual(new[1].name, "B")
+        self.assertEqual(new[2].name, "C")

--- a/toytree/cli/cli_relabel.py
+++ b/toytree/cli/cli_relabel.py
@@ -49,6 +49,7 @@ def run_relabel(args):
     tre = tre.relabel(
         queries=args.nodes,
         fn=fn,
+        imap=args.imap,
         delim=args.delim,
         delim_idxs=args.delim_idxs,
         delim_join=args.delim_join,

--- a/toytree/cli/subparsers.py
+++ b/toytree/cli/subparsers.py
@@ -2137,6 +2137,7 @@ def get_parser_relabel(parser: ArgumentParser | None = None) -> ArgumentParser:
             Examples
             --------
             $ relabel -i TRE.nwk --strip '_-'
+            $ relabel -i TRE.nwk --imap IMAP.txt
             $ relabel -i TRE.nwk --delim '|' --delim-idxs 0 2 --delim-join '_'
             $ relabel -i TRE.nwk -n '~^DE' --append '_X'
             $ relabel -i TRE.nwk --prepend 'sp_' --stripleft '._'
@@ -2206,6 +2207,12 @@ def get_parser_relabel(parser: ArgumentParser | None = None) -> ArgumentParser:
         default=True,
         metavar="bool",
         help="relabel only tips (true/false) [default: true]",
+    )
+    relabel_group.add_argument(
+        "--imap",
+        type=Path,
+        metavar="path",
+        help="optional whitespace-delimited tip-to-name mapping table",
     )
     relabel_group.add_argument(
         "--delim", type=str, metavar="str", help="delimiter for splitting names"

--- a/toytree/data/_src/relabel.py
+++ b/toytree/data/_src/relabel.py
@@ -4,7 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Callable, Sequence, TypeVar, Union
+import re
+import sys
+from collections.abc import Mapping as MappingABC
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence, TypeVar, Union
 
 from toytree import Node, ToyTree
 from toytree.core.apis import add_toytree_method
@@ -34,11 +38,102 @@ def _normalize_delim_idxs(delim_idxs):
     return [int(i) for i in delim_idxs]
 
 
+def _load_imap_file(path: str | Path) -> dict[str, str]:
+    """Load whitespace-delimited tip-name mappings from file."""
+    path = Path(path).expanduser()
+    mapping: dict[str, str] = {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for lnum, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if (not stripped) or stripped.startswith("#"):
+                    continue
+                parts = stripped.split()
+                if len(parts) < 2:
+                    raise ToytreeError(
+                        "imap file must have at least two whitespace-delimited "
+                        f"columns on line {lnum}."
+                    )
+                mapping[parts[0]] = parts[1]
+    except OSError as exc:
+        raise ToytreeError(f"could not read imap file '{path}': {exc}") from exc
+    if not mapping:
+        raise ToytreeError("imap file did not contain any usable selector/name rows.")
+    return mapping
+
+
+def _coerce_imap_mapping(
+    imap: Mapping[str, Any] | str | Path | None,
+) -> dict[str, Any]:
+    """Return imap as a selector->replacement mapping."""
+    if imap is None:
+        return {}
+    if isinstance(imap, MappingABC):
+        raw = dict(imap)
+    elif isinstance(imap, (str, Path)):
+        raw = _load_imap_file(imap)
+    else:
+        raise ToytreeError("imap must be a mapping, file path string, Path, or None.")
+
+    mapping: dict[str, Any] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            raise ToytreeError("imap selectors must be strings.")
+        mapping[key] = value
+    return mapping
+
+
+def _match_tip_selector(tree: ToyTree, selector: str) -> list[Node]:
+    """Return tip Nodes matched by one exact-name or regex selector."""
+    nodes = list(tree[: tree.ntips])
+    if selector.startswith("~"):
+        try:
+            regex = re.compile(selector[1:])
+        except re.error as exc:
+            msg = f"invalid regex query '{selector}' raised re.error:\n{exc}"
+            raise ToytreeError(msg) from exc
+        return [node for node in nodes if regex.search(node.name)]
+    return [node for node in nodes if node.name == selector]
+
+
+def _resolve_tip_imap(
+    tree: ToyTree,
+    imap: Mapping[str, Any] | str | Path | None,
+) -> dict[Node, Any]:
+    """Resolve imap selectors to uniquely matched tip Nodes."""
+    mapping = _coerce_imap_mapping(imap)
+    resolved: dict[Node, Any] = {}
+    selectors: dict[Node, str] = {}
+    for selector, value in mapping.items():
+        matches = _match_tip_selector(tree, selector)
+        if not matches:
+            print(
+                f"WARNING: imap selector '{selector}' did not match any tip names.",
+                file=sys.stderr,
+            )
+            continue
+        if len(matches) > 1:
+            names = ", ".join(node.name for node in matches)
+            raise ToytreeError(
+                f"imap selector '{selector}' matched multiple tips: {names}."
+            )
+        node = matches[0]
+        if node in resolved:
+            raise ToytreeError(
+                "imap selectors "
+                f"'{selectors[node]}' and '{selector}' both matched tip '{node.name}'."
+            )
+        resolved[node] = value
+        selectors[node] = selector
+    return resolved
+
+
 @add_toytree_method(ToyTree)
 def relabel(
     tree: ToyTree,
     queries: Union[Query, Sequence[Query], None] = None,
     fn: Callable[[str], str] | None = None,
+    imap: Mapping[str, Any] | str | Path | None = None,
     delim: str | None = None,
     delim_idxs: int | Sequence[int] | None = None,
     delim_join: str = "_",
@@ -58,6 +153,11 @@ def relabel(
     fn: Callable[[str], str] | None
         Optional callable transform applied to each selected name after
         delimiter processing.
+    imap: Mapping[str, Any] | str | Path | None
+        Optional tip-name remapping entered as a selector->replacement
+        mapping or as a whitespace-delimited file path. Selectors target
+        current tip names only, and strings prefixed with ``~`` are
+        treated as regex queries that must still match exactly one tip.
     delim: str | None
         Optional delimiter used to split names before selecting parts.
     delim_idxs: int | Sequence[int] | None
@@ -78,12 +178,16 @@ def relabel(
 
     Notes
     -----
-    Empty node names are skipped and left unchanged.
+    Empty node names are skipped and left unchanged. When ``imap`` is
+    provided its replacements are resolved against current tip names
+    before any transforms, then applied afterward as the final override
+    on those matched tips.
     """
     if fn is not None and not callable(fn):
         raise ToytreeError("fn must be callable or None.")
 
     tree = tree if inplace else tree.copy()
+    resolved_imap = _resolve_tip_imap(tree, imap)
 
     norm_queries = _normalize_queries(queries)
     if norm_queries is None:
@@ -128,4 +232,12 @@ def relabel(
                 if not has_bold:
                     new_name = f"<b>{new_name}</b>"
             node.name = new_name
+
+    for node, new_name in resolved_imap.items():
+        if new_name is None:
+            continue
+        new_name = str(new_name)
+        if new_name == "":
+            continue
+        node.name = new_name
     return tree


### PR DESCRIPTION
## Summary
- add `imap` support to `ToyTree.relabel()` for dict and filepath inputs
- support whitespace-delimited mapping files with `~`-prefixed regex selectors and warning-on-miss behavior
- add API and CLI regression coverage for file parsing, unmatched selectors, ambiguity, collisions, and transform ordering

## Why
`relabel` could only rename through query-driven transforms. This change adds a direct mapping workflow for tip renaming in both the Python API and CLI while keeping file and dict inputs on the same resolution path.

## Validation
- `pytest -q tests/core/test_relabel.py tests/cli/test_relabel_cli.py`
- `pytest -q tests/cli/test_cli_shared_flag_help.py -k relabel`
- `ruff check --select E501 toytree/data/_src/relabel.py toytree/cli/cli_relabel.py tests/core/test_relabel.py tests/cli/test_relabel_cli.py`