### PR TITLE
Expand CLI tree workflows

### DIFF
--- a/tests/cli/test_draw_cli.py
+++ b/tests/cli/test_draw_cli.py
@@ -70,6 +70,79 @@ class TestDrawCLI(PytestCompat):
         args = self.parser.parse_args(["-i", "((a,b),c);", "-f", "PNG"])
         self.assertEqual(args.format, "png")
 
+    def test_parser_accepts_node_labels_style(self):
+        """Accept node-label style entries through short and long options."""
+        for option in ("-L", "--node-labels-style"):
+            with self.subTest(option=option):
+                args = self.parser.parse_args(
+                    [
+                        "-i",
+                        "((a,b),c);",
+                        option,
+                        "font-size=12px",
+                        "fill=red",
+                    ]
+                )
+                self.assertEqual(
+                    args.node_labels_style,
+                    ["font-size=12px", "fill=red"],
+                )
+
+    def test_draw_applies_node_labels_style(self):
+        """Apply CLI node-label styles to the rendered node-label group."""
+        output = self.tmpdir / "styled-node-labels"
+        args = self.parser.parse_args(
+            [
+                "-i",
+                "((a,b),c);",
+                "-o",
+                str(output),
+                "-f",
+                "svg",
+                "-nl",
+                "idx",
+                "-L",
+                "font-size=12px",
+                "fill=red",
+            ]
+        )
+        self.assertEqual(run_draw(args), 0)
+
+        svg = output.with_suffix(".svg").read_text(encoding="utf-8")
+        start = svg.index('<g class="toytree-NodeLabels"')
+        end = svg.index('<g class="toytree-TipLabels"', start)
+        node_labels_svg = svg[start:end]
+        self.assertIn("font-size:12px", node_labels_svg)
+        self.assertIn("fill:rgb(100.0%,0.0%,0.0%)", node_labels_svg)
+
+    def test_draw_rejects_malformed_node_labels_style(self):
+        """Report malformed node-label style entries without a traceback."""
+        cmd = [
+            sys.executable,
+            "-m",
+            "toytree.cli.main",
+            "draw",
+            "-i",
+            "((a,b),c);",
+            "-o",
+            str(self.tmpdir / "tree"),
+            "-L",
+            "font-size",
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn(
+            "Error: --node-labels-style expects key=value entries",
+            proc.stderr,
+        )
+        self.assertNotIn("Traceback", proc.stderr)
+
+    def test_draw_help_includes_node_labels_style(self):
+        """Document the node-label style option and a visible-label example."""
+        help_text = self.parser.format_help()
+        self.assertIn("-L, --node-labels-style", help_text)
+        self.assertIn("-nl idx -L font-size=12px fill=red", help_text)
+
     def test_draw_accepts_binary_input_path_ascii_mode(self):
         """Render deprecated text mode from a binary input path."""
         tree = toytree.tree("((a:1,b:1):1,c:1);")

--- a/tests/cli/test_io_cli.py
+++ b/tests/cli/test_io_cli.py
@@ -4,7 +4,7 @@
 
 import io
 import tempfile
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from conftest import PytestCompat
@@ -35,6 +35,14 @@ class TestIOCLI(PytestCompat):
         with redirect_stdout(stream):
             run_io(args)
         return stream.getvalue().strip()
+
+    def _run_capture(self, argv):
+        args = self.parser.parse_args(argv)
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            run_io(args)
+        return out.getvalue().strip(), err.getvalue()
 
     def test_default_newick_roundtrip_keeps_support_and_features(self):
         """Default text mode should keep support labels and metadata features."""
@@ -254,5 +262,70 @@ class TestIOCLI(PytestCompat):
         with self.assertRaisesRegex(
             ToytreeError,
             "--features-pack cannot match --features-delim or --features-assignment",
+        ):
+            run_io(args)
+
+    def test_multitree_input_warns_and_uses_first_tree_by_default(self):
+        """Multitree text input should warn and emit the first tree by default."""
+        mtree_path = self.tmpdir / "trees.nwk"
+        mtree_path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+
+        out, err = self._run_capture(["-i", str(mtree_path)])
+
+        self.assertIn("Loading only the first tree", err)
+        self.assertEqual(toytree.tree(out).write(dist_formatter=None), "((a,b),c);")
+
+    def test_multitree_input_selects_requested_tree_without_warning(self):
+        """Explicit --index should select one multitree entry without warning."""
+        mtree_path = self.tmpdir / "trees_idx.nwk"
+        mtree_path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+
+        out, err = self._run_capture(["-i", str(mtree_path), "--index", "1"])
+
+        self.assertEqual(err, "")
+        self.assertEqual(toytree.tree(out).write(dist_formatter=None), "((a,c),b);")
+
+    def test_multitree_input_index_zero_suppresses_default_warning(self):
+        """Explicit --index 0 should select the first tree without warning."""
+        mtree_path = self.tmpdir / "trees_zero.nwk"
+        mtree_path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+
+        out, err = self._run_capture(["-i", str(mtree_path), "--index", "0"])
+
+        self.assertEqual(err, "")
+        self.assertEqual(toytree.tree(out).write(dist_formatter=None), "((a,b),c);")
+
+    def test_multitree_input_rejects_negative_index(self):
+        """Negative --index values should raise a clear range error."""
+        mtree_path = self.tmpdir / "trees_neg.nwk"
+        mtree_path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+        args = self.parser.parse_args(["-i", str(mtree_path), "--index", "-1"])
+
+        with self.assertRaisesRegex(ToytreeError, "--index -1 is out of range"):
+            run_io(args)
+
+    def test_multitree_input_rejects_out_of_range_index(self):
+        """Out-of-range --index values should raise a clear range error."""
+        mtree_path = self.tmpdir / "trees_oob.nwk"
+        mtree_path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+        args = self.parser.parse_args(["-i", str(mtree_path), "--index", "2"])
+
+        with self.assertRaisesRegex(ToytreeError, "--index 2 is out of range"):
+            run_io(args)
+
+    def test_single_tree_input_accepts_index_zero(self):
+        """Single-tree input should allow explicit --index 0."""
+        out, err = self._run_capture(["-i", str(self.tree_path), "--index", "0"])
+
+        self.assertEqual(err, "")
+        self.assertEqual(toytree.tree(out).ntips, 3)
+
+    def test_single_tree_input_rejects_nonzero_index(self):
+        """Single-tree input should reject nonzero indexes."""
+        args = self.parser.parse_args(["-i", str(self.tree_path), "--index", "1"])
+
+        with self.assertRaisesRegex(
+            ToytreeError,
+            "--index 1 is invalid for input containing a single tree",
         ):
             run_io(args)

--- a/tests/cli/test_relabel_cli.py
+++ b/tests/cli/test_relabel_cli.py
@@ -89,7 +89,7 @@ class TestRelabelCLI(PytestCompat):
     def test_imap_file_renames_tips_and_ignores_extra_columns(self):
         imap = self.tmpdir / "imap.txt"
         imap.write_text(
-            "aa|x alpha extra\nab|y beta ignored\n",
+            "aa|x\talpha\textra\nab|y\tbeta\tignored\n",
             encoding="utf-8",
         )
         out_nwk, err = self._run_capture(
@@ -101,10 +101,25 @@ class TestRelabelCLI(PytestCompat):
         self.assertEqual(tree[1].name, "beta")
         self.assertEqual(tree[2].name, "c|z")
 
+    def test_imap_file_supports_new_names_with_spaces(self):
+        imap = self.tmpdir / "imap_spaces.txt"
+        imap.write_text(
+            "aa|x\talpha one\nab|y\tbeta two\n",
+            encoding="utf-8",
+        )
+        out = self.tmpdir / "imap_spaces.bin"
+        args = self.parser.parse_args(
+            ["-i", str(self.tree_path), "--imap", str(imap), "-b", "-o", str(out)]
+        )
+        run_relabel(args)
+        tree = read_tree_auto(str(out))
+        self.assertEqual(tree[0].name, "alpha one")
+        self.assertEqual(tree[1].name, "beta two")
+
     def test_imap_warns_on_unmatched_and_still_writes_tree(self):
         imap = self.tmpdir / "imap_warn.txt"
         imap.write_text(
-            "missing nope\nc|z charlie\n",
+            "missing\tnope\nc|z\tcharlie\n",
             encoding="utf-8",
         )
         out_nwk, err = self._run_capture(
@@ -119,7 +134,7 @@ class TestRelabelCLI(PytestCompat):
 
     def test_imap_overrides_prior_transforms(self):
         imap = self.tmpdir / "imap_override.txt"
-        imap.write_text("aa|x alpha\n", encoding="utf-8")
+        imap.write_text("aa|x\talpha\n", encoding="utf-8")
         out_nwk, _ = self._run_capture(
             [
                 "-i",

--- a/tests/cli/test_tree_transport.py
+++ b/tests/cli/test_tree_transport.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
+import io
 import pickle
 import tempfile
+from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -67,6 +69,30 @@ class TestTreeTransport(PytestCompat):
         self.assertIsInstance(tre, ToyTree)
         self.assertEqual(tre.ntips, self.tree.ntips)
 
+    def test_read_tree_auto_multitree_text_path_warns_and_uses_first_by_default(self):
+        path = self.tmpdir / "trees.nwk"
+        path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tre = read_tree_auto(str(path))
+        self.assertEqual(tre.write(dist_formatter=None), "((a,b),c);")
+        self.assertIn("Loading only the first tree", err.getvalue())
+
+    def test_read_tree_auto_multitree_text_path_selects_by_index(self):
+        path = self.tmpdir / "trees_idx.nwk"
+        path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tre = read_tree_auto(str(path), tree_index=1)
+        self.assertEqual(tre.write(dist_formatter=None), "((a,c),b);")
+        self.assertEqual(err.getvalue(), "")
+
+    def test_read_tree_auto_multitree_text_path_rejects_bad_index(self):
+        path = self.tmpdir / "trees_oob.nwk"
+        path.write_text("((a,b),c);\n((a,c),b);\n", encoding="utf-8")
+        with self.assertRaisesRegex(ToytreeError, "--index 2 is out of range"):
+            read_tree_auto(str(path), tree_index=2)
+
     def test_read_tree_auto_binary_path(self):
         path = self.tmpdir / "tree.bin"
         path.write_bytes(serialize_tree_binary(self.tree))
@@ -74,6 +100,21 @@ class TestTreeTransport(PytestCompat):
         self.assertIsInstance(tre, ToyTree)
         self.assertEqual(tre.ntips, self.tree.ntips)
         self.assertEqual(tre.get_tip_labels(), self.tree.get_tip_labels())
+
+    def test_read_tree_auto_binary_path_accepts_index_zero(self):
+        path = self.tmpdir / "tree_idx0.bin"
+        path.write_bytes(serialize_tree_binary(self.tree))
+        tre = read_tree_auto(str(path), tree_index=0)
+        self.assertEqual(tre.get_tip_labels(), self.tree.get_tip_labels())
+
+    def test_read_tree_auto_binary_path_rejects_nonzero_index(self):
+        path = self.tmpdir / "tree_idx1.bin"
+        path.write_bytes(serialize_tree_binary(self.tree))
+        with self.assertRaisesRegex(
+            ToytreeError,
+            "--index 1 is invalid for input containing a single tree",
+        ):
+            read_tree_auto(str(path), tree_index=1)
 
     def test_read_tree_auto_legacy_pickled_toytree_raises(self):
         path = self.tmpdir / "legacy-tree.bin"

--- a/tests/core/test_relabel.py
+++ b/tests/core/test_relabel.py
@@ -100,10 +100,23 @@ class TestRelabel(PytestCompat):
 
     def test_imap_file_ignores_extra_columns(self):
         imap = self.tmpdir / "imap.txt"
-        imap.write_text("a-1 alpha extra\nc-3 charlie ignored\n", encoding="utf-8")
+        imap.write_text("a-1\talpha\textra\nc-3\tcharlie\tignored\n", encoding="utf-8")
         new = self.tree.relabel(imap=imap, inplace=False)
         self.assertEqual(new[0].name, "alpha")
         self.assertEqual(new[2].name, "charlie")
+
+    def test_imap_file_preserves_spaces_in_new_names(self):
+        imap = self.tmpdir / "imap_spaces.txt"
+        imap.write_text("a-1\talpha one\nc-3\tcharlie three\n", encoding="utf-8")
+        new = self.tree.relabel(imap=imap, inplace=False)
+        self.assertEqual(new[0].name, "alpha one")
+        self.assertEqual(new[2].name, "charlie three")
+
+    def test_imap_file_row_without_tab_raises_clear_error(self):
+        imap = self.tmpdir / "imap_bad.txt"
+        imap.write_text("a-1 alpha\n", encoding="utf-8")
+        with self.assertRaisesRegex(Exception, "two tab-delimited columns"):
+            self.tree.relabel(imap=imap, inplace=False)
 
     def test_imap_warns_on_unmatched_and_continues(self):
         buf = io.StringIO()

--- a/toytree/cli/_tree_transport.py
+++ b/toytree/cli/_tree_transport.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from toytree.utils import ToytreeError
 
 if TYPE_CHECKING:
+    from toytree.core.multitree import MultiTree
     from toytree.core.tree import ToyTree
 
 
@@ -95,6 +96,33 @@ def deserialize_tree_binary(data: bytes) -> "ToyTree":
     return ToyTree(node)
 
 
+def _select_tree_index(
+    tree: "ToyTree | MultiTree",
+    tree_index: int | None,
+) -> "ToyTree":
+    """Return one tree, optionally selecting from a parsed ``MultiTree``."""
+    from toytree.core.multitree import MultiTree
+    from toytree.io.src.parse import _warn_multiple_trees
+
+    if isinstance(tree, MultiTree):
+        if tree_index is None:
+            _warn_multiple_trees(tree.ntrees)
+            return tree[0]
+        if tree_index < 0 or tree_index >= tree.ntrees:
+            raise ToytreeError(
+                f"--index {tree_index} is out of range for input containing "
+                f"{tree.ntrees} trees."
+            )
+        return tree[tree_index]
+
+    if tree_index in (None, 0):
+        return tree
+
+    raise ToytreeError(
+        f"--index {tree_index} is invalid for input containing a single tree."
+    )
+
+
 def _parse_tree_from_bytes(
     data: bytes,
     internal_labels: str | None = None,
@@ -103,9 +131,9 @@ def _parse_tree_from_bytes(
     feature_assignment: str = "=",
     feature_unpack: str = "|",
     prefer_text: bool = False,
-) -> "ToyTree":
+) -> "ToyTree | MultiTree":
     """Parse bytes as binary transport payload or text tree data."""
-    from toytree.io.src.treeio import tree as parse_tree
+    from toytree.io.src.parse import parse_tree_object
 
     if prefer_text:
         try:
@@ -114,7 +142,7 @@ def _parse_tree_from_bytes(
             text = None
         if text is not None:
             try:
-                return parse_tree(
+                return parse_tree_object(
                     text,
                     internal_labels=internal_labels,
                     feature_prefix=feature_prefix,
@@ -135,7 +163,7 @@ def _parse_tree_from_bytes(
             "could not parse tree input as binary transport payload or UTF-8 text."
         ) from exc
     try:
-        return parse_tree(
+        return parse_tree_object(
             text,
             internal_labels=internal_labels,
             feature_prefix=feature_prefix,
@@ -157,9 +185,10 @@ def read_tree_auto(
     feature_delim: str = ",",
     feature_assignment: str = "=",
     feature_unpack: str = "|",
+    tree_index: int | None = None,
 ) -> "ToyTree":
     """Read tree from CLI input, auto-detecting binary or text for stdin/path."""
-    from toytree.io.src.treeio import tree as parse_tree
+    from toytree.io.src.parse import parse_tree_object
 
     stripped = input_arg.strip()
 
@@ -167,7 +196,7 @@ def read_tree_auto(
         data = sys.stdin.buffer.read()
         if not data:
             raise ToytreeError("no data received on stdin.")
-        return _parse_tree_from_bytes(
+        parsed = _parse_tree_from_bytes(
             data,
             internal_labels=internal_labels,
             feature_prefix=feature_prefix,
@@ -176,9 +205,10 @@ def read_tree_auto(
             feature_unpack=feature_unpack,
             prefer_text=_bytes_look_like_text_tree(data),
         )
+        return _select_tree_index(parsed, tree_index)
 
     if _looks_like_inline_tree_text(stripped):
-        return parse_tree(
+        parsed = parse_tree_object(
             input_arg,
             internal_labels=internal_labels,
             feature_prefix=feature_prefix,
@@ -186,9 +216,10 @@ def read_tree_auto(
             feature_assignment=feature_assignment,
             feature_unpack=feature_unpack,
         )
+        return _select_tree_index(parsed, tree_index)
 
     if stripped.startswith(("http://", "https://")):
-        return parse_tree(
+        parsed = parse_tree_object(
             input_arg,
             internal_labels=internal_labels,
             feature_prefix=feature_prefix,
@@ -196,11 +227,12 @@ def read_tree_auto(
             feature_assignment=feature_assignment,
             feature_unpack=feature_unpack,
         )
+        return _select_tree_index(parsed, tree_index)
 
     path = Path(input_arg)
     if path.exists():
         data = path.read_bytes()
-        return _parse_tree_from_bytes(
+        parsed = _parse_tree_from_bytes(
             data,
             internal_labels=internal_labels,
             feature_prefix=feature_prefix,
@@ -211,8 +243,9 @@ def read_tree_auto(
                 _path_has_text_tree_suffix(path) or _bytes_look_like_text_tree(data)
             ),
         )
+        return _select_tree_index(parsed, tree_index)
 
-    return parse_tree(
+    parsed = parse_tree_object(
         input_arg,
         internal_labels=internal_labels,
         feature_prefix=feature_prefix,
@@ -220,6 +253,7 @@ def read_tree_auto(
         feature_assignment=feature_assignment,
         feature_unpack=feature_unpack,
     )
+    return _select_tree_index(parsed, tree_index)
 
 
 def write_tree_output(

--- a/toytree/cli/cli_draw.py
+++ b/toytree/cli/cli_draw.py
@@ -89,6 +89,7 @@ def run_draw(args):
 
     # parse dict-style cli inputs
     node_style = _parse_style_kv(args.node_style, "--node-style")
+    node_labels_style = _parse_style_kv(args.node_labels_style, "--node-labels-style")
     edge_style = _parse_style_kv(args.edge_style, "--edge-style")
     tip_labels_style = _parse_style_kv(args.tip_labels_style, "--tip-labels-style")
 
@@ -108,6 +109,7 @@ def run_draw(args):
         node_sizes=_scalar_or_list(args.node_sizes),
         node_colors=_scalar_or_list(args.node_colors),
         node_labels=args.node_labels,
+        node_labels_style=node_labels_style,
         edge_widths=_scalar_or_list(args.edge_widths),
         edge_colors=_scalar_or_list(args.edge_colors),
         edge_type=args.edge_type,

--- a/toytree/cli/cli_io.py
+++ b/toytree/cli/cli_io.py
@@ -51,13 +51,13 @@ def run_io(args) -> None:
     # without parsing/re-serializing the tree object.
     if args.binary_out:
         input_bytes: bytes | None = None
-        if input_arg == "-":
+        if input_arg == "-" and args.index is None:
             input_bytes = sys.stdin.buffer.read()
             if not input_bytes:
                 raise ToytreeError("no data received on stdin.")
         else:
             path = Path(input_arg)
-            if path.exists():
+            if path.exists() and args.index is None:
                 input_bytes = path.read_bytes()
         if input_bytes is not None and is_binary_tree_payload(input_bytes):
             if args.output:
@@ -74,6 +74,7 @@ def run_io(args) -> None:
         feature_delim=args.in_feature_delim,
         feature_assignment=args.in_feature_assignment,
         feature_unpack=args.in_feature_unpack,
+        tree_index=args.index,
     )
 
     # Binary mode is a direct transport of the in-memory tree object.

--- a/toytree/cli/subparsers.py
+++ b/toytree/cli/subparsers.py
@@ -482,6 +482,9 @@ def get_parser_io(parser: ArgumentParser | None = None) -> ArgumentParser:
             # convert binary back to Newick text
             $ io -i TRE.bin > TRE.nwk
 
+            # select a specific tree from multitree input by 0-index
+            $ io -i TREES.nwk --index 1
+
             # write Nexus using flag or output suffix
             $ io -i TRE.bin --nexus -o TRE.nex
             $ io -i TRE.bin -o TRE.nexus
@@ -540,6 +543,13 @@ def get_parser_io(parser: ArgumentParser | None = None) -> ArgumentParser:
         type=str,
         metavar="str",
         help="parse internal newick labels as this feature (overrides auto-detect)",
+    )
+    io_group.add_argument(
+        "--index",
+        type=int,
+        default=None,
+        metavar="int",
+        help="select a 0-indexed tree from multitree input [default: first tree]",
     )
     io_group.add_argument(
         "-x",
@@ -682,6 +692,7 @@ def get_parser_draw(parser: ArgumentParser | None = None) -> ArgumentParser:
             $ draw -i TRE.nwk -v -ta
             $ draw -i TRE.nwk -v -ta false
             $ draw -i TRE.nwk -v -N fill=red -E stroke=pink -T font-size=10px fill=blue
+            $ draw -i TRE.nwk -v -nl idx -L font-size=12px fill=red
             $ root -i TRE.nwk -n R | draw -i - -v
             """
         ),
@@ -819,6 +830,14 @@ def get_parser_draw(parser: ArgumentParser | None = None) -> ArgumentParser:
         type=str,
         metavar="str",
         help="node labels feature or literal",
+    )
+    node_group.add_argument(
+        "-L",
+        "--node-labels-style",
+        type=str,
+        metavar="str",
+        nargs="+",
+        help="node-label style key=value args",
     )
     node_group.add_argument(
         "-N",
@@ -2212,7 +2231,7 @@ def get_parser_relabel(parser: ArgumentParser | None = None) -> ArgumentParser:
         "--imap",
         type=Path,
         metavar="path",
-        help="optional whitespace-delimited tip-to-name mapping table",
+        help="optional tab-delimited tip-to-name mapping table",
     )
     relabel_group.add_argument(
         "--delim", type=str, metavar="str", help="delimiter for splitting names"

--- a/toytree/data/_src/relabel.py
+++ b/toytree/data/_src/relabel.py
@@ -39,7 +39,7 @@ def _normalize_delim_idxs(delim_idxs):
 
 
 def _load_imap_file(path: str | Path) -> dict[str, str]:
-    """Load whitespace-delimited tip-name mappings from file."""
+    """Load tab-delimited tip-name mappings from file."""
     path = Path(path).expanduser()
     mapping: dict[str, str] = {}
     try:
@@ -48,10 +48,10 @@ def _load_imap_file(path: str | Path) -> dict[str, str]:
                 stripped = line.strip()
                 if (not stripped) or stripped.startswith("#"):
                     continue
-                parts = stripped.split()
+                parts = line.rstrip("\r\n").split("\t")
                 if len(parts) < 2:
                     raise ToytreeError(
-                        "imap file must have at least two whitespace-delimited "
+                        "imap file must have at least two tab-delimited "
                         f"columns on line {lnum}."
                     )
                 mapping[parts[0]] = parts[1]
@@ -155,7 +155,7 @@ def relabel(
         delimiter processing.
     imap: Mapping[str, Any] | str | Path | None
         Optional tip-name remapping entered as a selector->replacement
-        mapping or as a whitespace-delimited file path. Selectors target
+        mapping or as a tab-delimited file path. Selectors target
         current tip names only, and strings prefixed with ``~`` are
         treated as regex queries that must still match exactly one tip.
     delim: str | None


### PR DESCRIPTION
## Summary

- add `io --index` support for selecting a tree from multi-tree input while preserving the existing first-tree default
- treat relabel IMAP files as tab-delimited so replacement names can contain spaces
- add `-L/--node-labels-style` support to the draw CLI
- cover the new parsing, validation, rendering, and transport behavior

## Validation

- `conda run -n toytree-dev python -m pytest -q tests/cli tests/core/test_relabel.py --maxfail=1` (248 passed, 1 optional performance test skipped)
- staged diff whitespace check passed